### PR TITLE
Returning preview response directly

### DIFF
--- a/Contentstack.Core/ContentstackClient.cs
+++ b/Contentstack.Core/ContentstackClient.cs
@@ -509,7 +509,7 @@ namespace Contentstack.Core
         ///     stack.LivePreviewQuery(query);
         /// </code>
         /// </example>
-        public async Task LivePreviewQueryAsync(Dictionary<string, string> query)
+        public async Task<JObject> LivePreviewQueryAsync(Dictionary<string, string> query)
         {
             if (query.Keys.Contains("content_type_uid"))
             {
@@ -530,6 +530,7 @@ namespace Contentstack.Core
                 this.LivePreviewConfig.LivePreview = hash;
             }
             this.LivePreviewConfig.PreviewResponse = await GetLivePreviewData();
+            return this.LivePreviewConfig.PreviewResponse;
         }
 
         /// <summary>


### PR DESCRIPTION
I don't know why it is marking every line as changed :S
The only change is in the method "LivePreviewQueryAsync":
Return type changed from Task to Task<JObject> and added "return this.LivePreviewConfig.PreviewResponse;" in the end to return the preview response directly.

Without these changes it is not easy (possible at all?) for the clients to get the preview response.

Changed lines:
``` C#

public async Task<JObject> LivePreviewQueryAsync(Dictionary<string, string> query)
{
    ...
    return this.LivePreviewConfig.PreviewResponse;
}
```