### PR TITLE
feat: :sparkles: add variant method implementation on Entry and Query

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -10,4 +10,4 @@ fileignoreconfig:
 - filename: Contentstack.Core/Models/Asset.cs
   checksum: 98b819cb9b1e6a9a9e5394ac23c07bc642a41c0c7512d169afc63afe3baa6fb3
 - filename: Contentstack.Core/Models/Query.cs
-  checksum: 9237bb4d3e862fad7f3c6d9bad47873758a18617dc9c90d28015dcea267fcd9e
+  checksum: ceea632e4ea870f35ad3bd313e9f8b4e5ec21aa86f006fca2e0a32945999ba67

--- a/Contentstack.Core/Models/Entry.cs
+++ b/Contentstack.Core/Models/Entry.cs
@@ -378,6 +378,56 @@ namespace Contentstack.Core.Models
 
         }
 
+
+
+        /// <summary>
+        /// To set variants header using Entry instance.
+        /// </summary>
+        /// <param name="variant_header">Entry instance</param>
+        /// <returns>Current instance of Entry, this will be useful for a chaining calls.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClinet(&quot;api_key&quot;, &quot;delivery_token&quot;, &quot;environment&quot;);
+        ///     Entry csEntry = stack.ContentType(&quot;contentType_id&quot;).Entry(&quot;entry_uid&quot;);
+        ///     
+        ///     csEntry.Variant("variant_entry_1");
+        ///     csEntry.Fetch&lt;Product&gt;().ContinueWith((entryResult) =&gt; {
+        ///         //Your callback code.
+        ///         //var result = entryResult.Result.GetMetadata();
+        ///     });
+        /// </code>
+        /// </example>
+        public Entry Variant(string variant_header)
+        {
+            this.SetHeader("x-cs-variant-uid", variant_header);
+            return this;
+        }
+
+
+
+        /// <summary>
+        /// To set multiple variants headers using Entry instance.
+        /// </summary>
+        /// <param name="variant_headers">Entry instance</param>
+        /// <returns>Current instance of Entry, this will be useful for a chaining calls.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClinet(&quot;api_key&quot;, &quot;delivery_token&quot;, &quot;environment&quot;);
+        ///     Entry csEntry = stack.ContentType(&quot;contentType_id&quot;).Query();
+        ///     
+        ///     csEntry.Variant(new List<string> { "variant_entry_1", "variant_entry_2", "variant_entry_3" });
+        ///     csEntry.Fetch&lt;Product&gt;().ContinueWith((entryResult) =&gt; {
+        ///         //Your callback code.
+        ///         //var result = entryResult.Result.GetMetadata();
+        ///     });
+        /// </code>
+        /// </example>
+        public Entry Variant(List<string> variant_headers)
+        {
+            this.SetHeader("x-cs-variant-uid", string.Join(",", variant_headers));
+            return this;
+        }
+
         /// <summary>
         /// Get metadata of entry.
         /// </summary>

--- a/Contentstack.Core/Models/Query.cs
+++ b/Contentstack.Core/Models/Query.cs
@@ -1686,6 +1686,54 @@ namespace Contentstack.Core.Models
             return this;
         }
 
+
+
+        /// <summary>
+        /// To set variants header using query instance.
+        /// </summary>
+        /// <param name="Variant">Query instance</param>
+        /// <returns>Current instance of Query, this will be useful for a chaining calls.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClinet(&quot;api_key&quot;, &quot;delivery_token&quot;, &quot;environment&quot;);
+        ///     Query csQuery = stack.ContentType(&quot;contentType_id&quot;).Query();
+        ///     
+        ///     csQuery.Variant("variant_entry_1");
+        ///     csQuery.Find&lt;Product&gt;().ContinueWith((queryResult) =&gt; {
+        ///         //Your callback code.
+        ///     });
+        /// </code>
+        /// </example>
+        public Query Variant(string variant_header)
+        {
+            this.SetHeader("x-cs-variant-uid", variant_header);
+            return this;
+        }
+
+
+
+        /// <summary>
+        /// To set multiple variants headers using query instance.
+        /// </summary>
+        /// <param name="Variant">Query instance</param>
+        /// <returns>Current instance of Query, this will be useful for a chaining calls.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClinet(&quot;api_key&quot;, &quot;delivery_token&quot;, &quot;environment&quot;);
+        ///     Query csQuery = stack.ContentType(&quot;contentType_id&quot;).Query();
+        ///     
+        ///     csQuery.Variant(new List<string> { "variant_entry_1", "variant_entry_2", "variant_entry_3" });
+        ///     csQuery.Find&lt;Product&gt;().ContinueWith((queryResult) =&gt; {
+        ///         //Your callback code.
+        ///     });
+        /// </code>
+        /// </example>
+        public Query Variant(List<string> variant_headers)
+        {
+            this.SetHeader("x-cs-variant-uid", string.Join(",", variant_headers));
+            return this;
+        }
+
         /// <summary>
         /// Execute a Query and Caches its result (Optional)
         /// </summary>


### PR DESCRIPTION
Adds Variants method to Entry and Query class 
- accepts single string for single header value and list of strings for mutiple header values
- returns the class instance for chaining calls