### PR TITLE
fix: register EmbeddedObjectConverter in ContentstackClient constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Version: 2.28.0
+#### Date: Jun-24-2026
+
+##### Fix:
+- Register `EmbeddedObjectConverter` in `ContentstackClient` constructor so `.includeEmbeddedItems().Fetch<T>()` deserializes `_embedded_items` correctly when the model implements `IEntryEmbedable`. No changes required in consumer code.
+- Upgraded utils dependency from `contentstack.utils 1.3.0` to `contentstack.utils 1.4.0` which ships the concrete `EmbeddedObject` class and `EmbeddedObjectConverter`.
+
 ### Version: 2.27.0
 #### Date: Apr-23-2026
 

--- a/Contentstack.Core/Contentstack.Core.csproj
+++ b/Contentstack.Core/Contentstack.Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Markdig" Version="0.36.2" />
-    <PackageReference Include="contentstack.utils" Version="1.0.6" />
+    <PackageReference Include="contentstack.utils" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Interfaces\" />

--- a/Contentstack.Core/ContentstackClient.cs
+++ b/Contentstack.Core/ContentstackClient.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.IO;
 using System.Collections;
 using Contentstack.Core.Interfaces;
+using Contentstack.Utils.Converters;
 
 namespace Contentstack.Core
 {
@@ -242,6 +243,9 @@ namespace Contentstack.Core
             {
                 SerializerSettings.Converters.Add((JsonConverter)Activator.CreateInstance(t));
             }
+
+            // Handles deserialization of embedded entries and assets in _embedded_items responses.
+            SerializerSettings.Converters.Add(new EmbeddedObjectConverter());
         }
 
         public ContentstackClient(ContentstackOptions options) :

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.27.0</Version>
+    <Version>2.28.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Register `EmbeddedObjectConverter` in `ContentstackClient` constructor so `.includeEmbeddedItems().Fetch<T>()` deserializes `_embedded_items` without crashing when the model implements `IEntryEmbedable`
- Bump `contentstack.utils` dependency to `1.4.0` which ships the concrete `EmbeddedObject` class and `EmbeddedObjectConverter`
- Version bump to `2.28.0`

## Problem

Customers calling `.includeEmbeddedItems().Fetch<T>()` on a model implementing `IEntryEmbedable` received a `JsonSerializationException` at runtime whenever the Delivery API returned `_embedded_items` in the response:

> Could not create an instance of type Contentstack.Utils.Interfaces.IEmbeddedObject.
> Type is an interface or abstract class and cannot be instantiated.
> Path 'entry._embedded_items.rte_json[0]._content_type_uid'

`IEntryEmbedable.embeddedItems` is typed as `Dictionary<string, List<IEmbeddedObject>>`. With no `JsonConverter` registered, Newtonsoft.Json tried to `new()` the interface directly and threw.

## Changes

### `ContentstackClient.cs`

One line added in the constructor after the existing `CSJsonConverterAttribute` loop:

```csharp
// Handles deserialization of embedded entries and assets in _embedded_items responses.
SerializerSettings.Converters.Add(new EmbeddedObjectConverter());
