### PR TITLE
feat: add localized taxonomy and term delivery (CDA) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Version: 2.29.0
+#### Date: Jul-15-2026
+
+##### Feat:
+- Taxonomy / Term localisation
+  - Added `includeFallback` parameter to `Term.Fetch<T>(string locale, bool includeFallback)` so callers can request master-locale fallback on single-term fetch, consistent with `TermQuery.IncludeFallback()`
+  - Fixed `include_fallback` serialization: the value is now sent as the string `"true"` instead of a C# `bool`, which was being serialized as `"True"` (capital T) and rejected by the CDA
+
 ### Version: 2.28.0
 #### Date: Jun-24-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### Version: 2.29.1
+#### Date: Jul-16-2026
+
+##### Fix:
+- Taxonomy / Term / TermQuery — branch handling
+  - Removed `?? "main"` fallback on `Config.Branch` in `Taxonomy.Fetch<T>()`, `Term.ExecuteRequest()`, and `TermQuery.Find<T>()`. The fallback was injecting `branch=main` into every CDA request when branching was not configured on the stack, causing `422 Branch not found` errors. Branch is now passed directly from `Config.Branch`, consistent with `Asset` and `Entry`.
+- Taxonomy / Term / TermQuery — structured error propagation
+  - Replaced `TaxonomyException.CreateForProcessingError(ex)` with `GetContentstackError(ex)` in all catch blocks across `Taxonomy.Fetch<T>()`, `Term.Fetch<T>()`, `Term.Locales<T>()`, `Term.Ancestors<T>()`, `Term.Descendants<T>()`, and `TermQuery.Find<T>()`. On 4xx responses, `ErrorCode`, `StatusCode`, and `Errors` are now correctly populated from the API response body, consistent with `Asset` and `Entry` error handling.
+- Taxonomy / Term — locale/fallback API convention alignment
+  - `Taxonomy.Fetch<T>()` and `Term.Fetch<T>()` no longer accept `locale` / `includeFallback` parameters. Use the new chainable `SetLocale(string)`, `IncludeFallback()`, and `AddParam(string, string)` methods before calling `Fetch<T>()`, matching the convention used by `Asset`, `Entry`, and `AssetLibrary`.
+  - Migration: `Taxonomies("uid").Fetch<T>("hi-in")` → `Taxonomies("uid").SetLocale("hi-in").Fetch<T>()`
+  - Migration: `Term("uid").Fetch<T>("hi-in", includeFallback: true)` → `Term("uid").SetLocale("hi-in").IncludeFallback().Fetch<T>()`
+
 ### Version: 2.29.0
 #### Date: Jul-15-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,22 @@
-### Version: 2.29.1
+### Version: 2.29.0
 #### Date: Jul-16-2026
+
+##### Feat:
+- Taxonomy / Term / TermQuery — localisation support
+  - Added `SetLocale(string)`, `IncludeFallback()`, and `AddParam(string, string)` chainable methods to `Taxonomy`, `Term`, and `TermQuery`, matching the convention used by `Asset`, `Entry`, and `AssetLibrary`
+  - `Taxonomy.Fetch<T>()` and `Term.Fetch<T>()` now read from the shared `UrlQueries` dict — locale and fallback are set via chaining, not method parameters
+  - Fixed `include_fallback` serialization: value is sent as the string `"true"` instead of a C# `bool` (which serialized as `"True"` and was rejected by the CDA)
+  - Added `AddParam(string, string)` to `TermQuery` (was missing)
 
 ##### Fix:
 - Taxonomy / Term / TermQuery — branch handling
-  - Removed `?? "main"` fallback on `Config.Branch` in `Taxonomy.Fetch<T>()`, `Term.ExecuteRequest()`, and `TermQuery.Find<T>()`. The fallback was injecting `branch=main` into every CDA request when branching was not configured on the stack, causing `422 Branch not found` errors. Branch is now passed directly from `Config.Branch`, consistent with `Asset` and `Entry`.
+  - Removed `?? "main"` fallback on `Config.Branch` across `Taxonomy.Fetch<T>()`, `Term.ExecuteRequest()`, and `TermQuery.Find<T>()`. The fallback was injecting `branch=main` into every CDA request when branching was not configured, causing `422 Branch not found` errors. Branch is now passed directly from `Config.Branch`, consistent with `Asset` and `Entry`.
 - Taxonomy / Term / TermQuery — structured error propagation
   - Replaced `TaxonomyException.CreateForProcessingError(ex)` with `GetContentstackError(ex)` in all catch blocks across `Taxonomy.Fetch<T>()`, `Term.Fetch<T>()`, `Term.Locales<T>()`, `Term.Ancestors<T>()`, `Term.Descendants<T>()`, and `TermQuery.Find<T>()`. On 4xx responses, `ErrorCode`, `StatusCode`, and `Errors` are now correctly populated from the API response body, consistent with `Asset` and `Entry` error handling.
-- Taxonomy / Term — locale/fallback API convention alignment
-  - `Taxonomy.Fetch<T>()` and `Term.Fetch<T>()` no longer accept `locale` / `includeFallback` parameters. Use the new chainable `SetLocale(string)`, `IncludeFallback()`, and `AddParam(string, string)` methods before calling `Fetch<T>()`, matching the convention used by `Asset`, `Entry`, and `AssetLibrary`.
-  - Migration: `Taxonomies("uid").Fetch<T>("hi-in")` → `Taxonomies("uid").SetLocale("hi-in").Fetch<T>()`
-  - Migration: `Term("uid").Fetch<T>("hi-in", includeFallback: true)` → `Term("uid").SetLocale("hi-in").IncludeFallback().Fetch<T>()`
 
-### Version: 2.29.0
-#### Date: Jul-15-2026
-
-##### Feat:
-- Taxonomy / Term localisation
-  - Added `includeFallback` parameter to `Term.Fetch<T>(string locale, bool includeFallback)` so callers can request master-locale fallback on single-term fetch, consistent with `TermQuery.IncludeFallback()`
-  - Fixed `include_fallback` serialization: the value is now sent as the string `"true"` instead of a C# `bool`, which was being serialized as `"True"` (capital T) and rejected by the CDA
+##### Migration:
+- `Taxonomies("uid").Fetch<T>("hi-in")` → `Taxonomies("uid").SetLocale("hi-in").Fetch<T>()`
+- `Term("uid").Fetch<T>("hi-in", includeFallback: true)` → `Term("uid").SetLocale("hi-in").IncludeFallback().Fetch<T>()`
 
 ### Version: 2.28.0
 #### Date: Jun-24-2026

--- a/Contentstack.Core.Tests/Helpers/TestDataHelper.cs
+++ b/Contentstack.Core.Tests/Helpers/TestDataHelper.cs
@@ -131,24 +131,6 @@ namespace Contentstack.Core.Tests.Helpers
             GetRequiredConfig("TAX_INDIA_STATE");
 
         /// <summary>
-        /// API key for the taxonomy-publish test stack (gadgets).
-        /// </summary>
-        public static string TaxPublishApiKey =>
-            GetRequiredConfig("TAX_PUBLISH_API_KEY");
-
-        /// <summary>
-        /// Delivery token for the taxonomy-publish test stack.
-        /// </summary>
-        public static string TaxPublishDeliveryToken =>
-            GetRequiredConfig("TAX_PUBLISH_DELIVERY_TOKEN");
-
-        /// <summary>
-        /// Environment for the taxonomy-publish test stack.
-        /// </summary>
-        public static string TaxPublishEnvironment =>
-            GetRequiredConfig("TAX_PUBLISH_ENVIRONMENT");
-
-        /// <summary>
         /// UID of the published taxonomy to use in localization tests (e.g. "gadgets").
         /// </summary>
         public static string TaxPublishTaxonomyUid =>

--- a/Contentstack.Core.Tests/Helpers/TestDataHelper.cs
+++ b/Contentstack.Core.Tests/Helpers/TestDataHelper.cs
@@ -117,19 +117,49 @@ namespace Contentstack.Core.Tests.Helpers
         #endregion
 
         #region Taxonomy
-        
+
         /// <summary>
         /// Gets the taxonomy term for USA state (e.g., "california")
         /// </summary>
-        public static string TaxUsaState => 
+        public static string TaxUsaState =>
             GetRequiredConfig("TAX_USA_STATE");
-        
+
         /// <summary>
         /// Gets the taxonomy term for India state (e.g., "maharashtra")
         /// </summary>
-        public static string TaxIndiaState => 
+        public static string TaxIndiaState =>
             GetRequiredConfig("TAX_INDIA_STATE");
-        
+
+        /// <summary>
+        /// API key for the taxonomy-publish test stack (gadgets).
+        /// </summary>
+        public static string TaxPublishApiKey =>
+            GetRequiredConfig("TAX_PUBLISH_API_KEY");
+
+        /// <summary>
+        /// Delivery token for the taxonomy-publish test stack.
+        /// </summary>
+        public static string TaxPublishDeliveryToken =>
+            GetRequiredConfig("TAX_PUBLISH_DELIVERY_TOKEN");
+
+        /// <summary>
+        /// Environment for the taxonomy-publish test stack.
+        /// </summary>
+        public static string TaxPublishEnvironment =>
+            GetRequiredConfig("TAX_PUBLISH_ENVIRONMENT");
+
+        /// <summary>
+        /// UID of the published taxonomy to use in localization tests (e.g. "gadgets").
+        /// </summary>
+        public static string TaxPublishTaxonomyUid =>
+            GetRequiredConfig("TAX_PUBLISH_TAXONOMY_UID");
+
+        /// <summary>
+        /// Locale code used for localized taxonomy/term delivery tests (e.g. "hi-in").
+        /// </summary>
+        public static string TaxPublishLocale =>
+            GetRequiredConfig("TAX_PUBLISH_LOCALE");
+
         #endregion
 
         #region Live Preview

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Contentstack.Core.Configuration;
+using Contentstack.Core.Models;
+using Contentstack.Core.Internals;
+using Contentstack.Core.Tests.Helpers;
+
+namespace Contentstack.Core.Tests.Integration.Taxonomy
+{
+    /// <summary>
+    /// Integration tests for localized taxonomy and term delivery (CDA).
+    /// Covers: Taxonomy.Fetch(locale), TermQuery.SetLocale/IncludeFallback/Find,
+    /// Term.Fetch(locale), Term.Locales, Term.Ancestors, Term.Descendants.
+    /// Stack: gadgets taxonomy, locales en-us / hi-in.
+    /// </summary>
+    [Trait("Category", "TaxonomyLocalisation")]
+    public class TaxonomyLocalisationTest : IntegrationTestBase
+    {
+        public TaxonomyLocalisationTest(ITestOutputHelper output) : base(output) { }
+
+        /// <summary>
+        /// Creates a client scoped to the gadgets taxonomy-publish test stack.
+        /// Uses the default CDN host (no custom host override needed).
+        /// </summary>
+        private ContentstackClient CreateGadgetsClient()
+        {
+            var options = new ContentstackOptions
+            {
+                ApiKey = TestDataHelper.TaxPublishApiKey,
+                DeliveryToken = TestDataHelper.TaxPublishDeliveryToken,
+                Environment = TestDataHelper.TaxPublishEnvironment
+            };
+            var client = new ContentstackClient(options);
+            client.Plugins.Add(new RequestLoggingPlugin(TestOutput));
+            return client;
+        }
+
+        // ── 1. Fetch localized taxonomy ──────────────────────────────────────
+
+        [Fact(DisplayName = "TaxPublish - Fetch taxonomy returns object with uid and name")]
+        public async Task Fetch_Taxonomy_MasterLocale_ReturnsValidObject()
+        {
+            LogArrange("Fetching taxonomy without locale (master)");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+
+            var client = CreateGadgetsClient();
+
+            LogAct("Calling Taxonomies(uid).Fetch<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Fetch<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result["uid"]?.ToString());
+            Assert.Equal(TestDataHelper.TaxPublishTaxonomyUid, result["uid"]?.ToString());
+        }
+
+        [Fact(DisplayName = "TaxPublish - Fetch taxonomy with locale returns localized name")]
+        public async Task Fetch_Taxonomy_WithLocale_ReturnsLocalizedName()
+        {
+            LogArrange("Fetching taxonomy with locale");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            var client = CreateGadgetsClient();
+
+            LogAct("Calling Taxonomies(uid).Fetch<JObject>(locale)");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale);
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result["uid"]?.ToString());
+            // The name should differ from the master locale (en-us) value
+            Assert.NotNull(result["name"]?.ToString());
+        }
+
+        // ── 2. Find all taxonomies ────────────────────────────────────────────
+
+        [Fact(DisplayName = "TaxPublish - Find all taxonomies returns non-empty collection")]
+        public async Task Find_AllTaxonomies_ReturnsCollection()
+        {
+            LogArrange("Fetching all published taxonomies");
+
+            var client = CreateGadgetsClient();
+
+            LogAct("Calling Taxonomies().Find<Entry>()");
+            var result = await client.Taxonomies().Find<Entry>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result.Items);
+        }
+
+        // ── 3. Find terms with locale ─────────────────────────────────────────
+
+        [Fact(DisplayName = "TaxPublish - Find terms with locale returns localized terms")]
+        public async Task Find_Terms_WithLocale_ReturnsLocalizedTerms()
+        {
+            LogArrange("Finding terms with locale");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            var client = CreateGadgetsClient();
+
+            LogAct("Calling Terms().SetLocale(locale).Find<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .Find<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result.Items);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Find terms with locale and fallback returns terms")]
+        public async Task Find_Terms_WithLocaleAndFallback_ReturnsTerms()
+        {
+            LogArrange("Finding terms with locale and include_fallback");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            var client = CreateGadgetsClient();
+
+            LogAct("Calling Terms().SetLocale(locale).IncludeFallback().Find<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .IncludeFallback()
+                .Find<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result.Items);
+            // Fallback means we should get at least as many terms as without fallback
+            Assert.True(result.Items.Any());
+        }
+
+        // ── 4–7. Single term methods ──────────────────────────────────────────
+
+        /// <summary>
+        /// Fetches the first available term UID from the gadgets taxonomy to use in subsequent tests.
+        /// </summary>
+        private async Task<string> GetFirstTermUidAsync(ContentstackClient client)
+        {
+            var terms = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .IncludeFallback()
+                .Find<Newtonsoft.Json.Linq.JObject>();
+
+            return terms?.Items?.FirstOrDefault()?["uid"]?.ToString();
+        }
+
+        [Fact(DisplayName = "TaxPublish - Fetch single term with locale returns localized term")]
+        public async Task Fetch_SingleTerm_WithLocale_ReturnsLocalizedTerm()
+        {
+            var client = CreateGadgetsClient();
+            var termUid = await GetFirstTermUidAsync(client);
+
+            if (string.IsNullOrEmpty(termUid))
+            {
+                Output.WriteLine("No term UID found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching single term with locale");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("TermUid", termUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            LogAct("Calling Term(termUid).Fetch<JObject>(locale)");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(termUid)
+                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale);
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result["uid"]?.ToString());
+            Assert.Equal(termUid, result["uid"]?.ToString());
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Locales returns locales collection")]
+        public async Task Term_Locales_ReturnsLocalesCollection()
+        {
+            var client = CreateGadgetsClient();
+            var termUid = await GetFirstTermUidAsync(client);
+
+            if (string.IsNullOrEmpty(termUid))
+            {
+                Output.WriteLine("No term UID found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching all locales for a term");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("TermUid", termUid);
+
+            LogAct("Calling Term(termUid).Locales<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(termUid)
+                .Locales<Newtonsoft.Json.Linq.JToken>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Ancestors returns ancestors collection")]
+        public async Task Term_Ancestors_ReturnsAncestorsCollection()
+        {
+            var client = CreateGadgetsClient();
+            var termUid = await GetFirstTermUidAsync(client);
+
+            if (string.IsNullOrEmpty(termUid))
+            {
+                Output.WriteLine("No term UID found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching ancestors for a term");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("TermUid", termUid);
+
+            LogAct("Calling Term(termUid).Ancestors<JToken>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(termUid)
+                .Ancestors<Newtonsoft.Json.Linq.JToken>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Descendants returns descendants collection")]
+        public async Task Term_Descendants_ReturnsDescendantsCollection()
+        {
+            var client = CreateGadgetsClient();
+            var termUid = await GetFirstTermUidAsync(client);
+
+            if (string.IsNullOrEmpty(termUid))
+            {
+                Output.WriteLine("No term UID found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching descendants for a term");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+            LogContext("TermUid", termUid);
+
+            LogAct("Calling Term(termUid).Descendants<JToken>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(termUid)
+                .Descendants<Newtonsoft.Json.Linq.JToken>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+        }
+    }
+}

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -83,19 +83,24 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
 
         // ── 2. Find all taxonomies ────────────────────────────────────────────
 
-        [Fact(DisplayName = "TaxPublish - Find all taxonomies returns non-empty collection")]
+        [Fact(DisplayName = "TaxPublish - Find all terms without locale returns master-locale terms")]
         public async Task Find_AllTaxonomies_ReturnsCollection()
         {
-            LogArrange("Fetching all published taxonomies");
+            LogArrange("Fetching all terms in master locale (no locale filter)");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
 
             var client = CreateGadgetsClient();
 
-            LogAct("Calling Taxonomies().Find<Entry>()");
-            var result = await client.Taxonomies().Find<Entry>();
+            LogAct("Calling Taxonomies(uid).Terms().Find<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .Find<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);
             Assert.NotNull(result.Items);
+            Assert.True(result.Items.Any());
         }
 
         // ── 3. Find terms with locale ─────────────────────────────────────────
@@ -179,11 +184,11 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             LogContext("TermUid", termUid);
             LogContext("Locale", TestDataHelper.TaxPublishLocale);
 
-            LogAct("Calling Term(termUid).Fetch<JObject>(locale)");
+            LogAct("Calling Term(termUid).Fetch<JObject>(locale, includeFallback: true)");
             var result = await client
                 .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
                 .Term(termUid)
-                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale);
+                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale, includeFallback: true);
 
             LogAssert("Verifying response");
             Assert.NotNull(result);

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -23,16 +23,16 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
         public TaxonomyLocalisationTest(ITestOutputHelper output) : base(output) { }
 
         /// <summary>
-        /// Creates a client scoped to the gadgets taxonomy-publish test stack.
+        /// Creates a client scoped to the main test stack, which also carries the
         /// Uses the default CDN host (no custom host override needed).
         /// </summary>
         private ContentstackClient CreateGadgetsClient()
         {
             var options = new ContentstackOptions
             {
-                ApiKey = TestDataHelper.TaxPublishApiKey,
-                DeliveryToken = TestDataHelper.TaxPublishDeliveryToken,
-                Environment = TestDataHelper.TaxPublishEnvironment
+                ApiKey = TestDataHelper.ApiKey,
+                DeliveryToken = TestDataHelper.DeliveryToken,
+                Environment = TestDataHelper.Environment
             };
             var client = new ContentstackClient(options);
             client.Plugins.Add(new RequestLoggingPlugin(TestOutput));

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -23,8 +23,8 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
         public TaxonomyLocalisationTest(ITestOutputHelper output) : base(output) { }
 
         /// <summary>
-        /// Creates a client scoped to the main test stack, which also carries the
-        /// Uses the default CDN host (no custom host override needed).
+        /// Creates a client scoped to the gadgets taxonomy stack.
+        /// Host must be set from config — the test stack lives on a non-prod CDN.
         /// </summary>
         private ContentstackClient CreateGadgetsClient()
         {
@@ -32,7 +32,8 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             {
                 ApiKey = TestDataHelper.ApiKey,
                 DeliveryToken = TestDataHelper.DeliveryToken,
-                Environment = TestDataHelper.Environment
+                Environment = TestDataHelper.Environment,
+                Host = TestDataHelper.Host
             };
             var client = new ContentstackClient(options);
             client.Plugins.Add(new RequestLoggingPlugin(TestOutput));

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -69,10 +69,11 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
 
             var client = CreateGadgetsClient();
 
-            LogAct("Calling Taxonomies(uid).Fetch<JObject>(locale)");
+            LogAct("Calling Taxonomies(uid).SetLocale(locale).Fetch<JObject>()");
             var result = await client
                 .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
-                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale);
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .Fetch<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);
@@ -183,11 +184,13 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             LogContext("TermUid", termUid);
             LogContext("Locale", TestDataHelper.TaxPublishLocale);
 
-            LogAct("Calling Term(termUid).Fetch<JObject>(locale, includeFallback: true)");
+            LogAct("Calling Term(termUid).SetLocale(locale).IncludeFallback().Fetch<JObject>()");
             var result = await client
                 .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
                 .Term(termUid)
-                .Fetch<Newtonsoft.Json.Linq.JObject>(TestDataHelper.TaxPublishLocale, includeFallback: true);
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .IncludeFallback()
+                .Fetch<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -141,7 +141,6 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             LogAssert("Verifying response");
             Assert.NotNull(result);
             Assert.NotNull(result.Items);
-            // Fallback means we should get at least as many terms as without fallback
             Assert.True(result.Items.Any());
         }
 

--- a/Contentstack.Core.Unit.Tests/QueryUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/QueryUnitTests.cs
@@ -2437,8 +2437,8 @@ namespace Contentstack.Core.Unit.Tests
 
             // Act - Just verify setup - Taxonomy extends Query, so it has QueryInstance properties
             var taxonomyType = typeof(Taxonomy);
-            var stackProperty = taxonomyType.GetProperty("Stack", 
-                BindingFlags.Public | BindingFlags.Instance);
+            var stackProperty = taxonomyType.GetProperty("Stack",
+                BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Assert
             Assert.NotNull(taxonomy);
@@ -2460,8 +2460,8 @@ namespace Contentstack.Core.Unit.Tests
 
             // Act - Just verify setup
             var taxonomyType = typeof(Taxonomy);
-            var stackProperty = taxonomyType.GetProperty("Stack", 
-                BindingFlags.Public | BindingFlags.Instance);
+            var stackProperty = taxonomyType.GetProperty("Stack",
+                BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Assert
             Assert.NotNull(taxonomy);
@@ -2484,8 +2484,8 @@ namespace Contentstack.Core.Unit.Tests
 
             // Act - Just verify setup
             var taxonomyType = typeof(Taxonomy);
-            var stackProperty = taxonomyType.GetProperty("Stack", 
-                BindingFlags.Public | BindingFlags.Instance);
+            var stackProperty = taxonomyType.GetProperty("Stack",
+                BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Assert
             Assert.NotNull(taxonomy);

--- a/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
@@ -563,6 +563,169 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         #endregion
+
+        #region Taxonomy UID Constructor Tests
+
+        [Fact]
+        public void Taxonomy_WithUid_DoesNotThrow()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            Assert.NotNull(taxonomy);
+        }
+
+        [Fact]
+        public void Taxonomy_WithNullUid_ThrowsTaxonomyException()
+        {
+            Assert.Throws<TaxonomyException>(() => _client.Taxonomies(null));
+        }
+
+        [Fact]
+        public void Taxonomy_WithEmptyUid_ThrowsTaxonomyException()
+        {
+            Assert.Throws<TaxonomyException>(() => _client.Taxonomies(string.Empty));
+        }
+
+        #endregion
+
+        #region Taxonomy.Term() Tests
+
+        [Fact]
+        public void Taxonomy_TermWithUid_ReturnsTaxonomyInstance()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            var term = taxonomy.Term("smartwatch");
+            Assert.NotNull(term);
+            Assert.IsType<Term>(term);
+        }
+
+        [Fact]
+        public void Taxonomy_TermWithoutUid_ThrowsTaxonomyException()
+        {
+            var taxonomy = _client.Taxonomies();
+            Assert.Throws<TaxonomyException>(() => taxonomy.Term("smartwatch"));
+        }
+
+        #endregion
+
+        #region Taxonomy.Terms() Tests
+
+        [Fact]
+        public void Taxonomy_Terms_ReturnsTermQueryInstance()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            var termQuery = taxonomy.Terms();
+            Assert.NotNull(termQuery);
+            Assert.IsType<TermQuery>(termQuery);
+        }
+
+        [Fact]
+        public void Taxonomy_Terms_WithoutUid_ThrowsTaxonomyException()
+        {
+            var taxonomy = _client.Taxonomies();
+            Assert.Throws<TaxonomyException>(() => taxonomy.Terms());
+        }
+
+        #endregion
+
+        #region TermQuery Tests
+
+        [Fact]
+        public void TermQuery_SetLocale_ReturnsSelfForChaining()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            var result = termQuery.SetLocale("hi-in");
+            Assert.Same(termQuery, result);
+        }
+
+        [Fact]
+        public void TermQuery_SetLocale_SetsLocaleParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.SetLocale("hi-in");
+
+            var field = typeof(TermQuery).GetField("_queryParams",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("locale") ?? false);
+            Assert.Equal("hi-in", queryParams["locale"]);
+        }
+
+        [Fact]
+        public void TermQuery_SetLocale_WithNull_ThrowsTaxonomyException()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            Assert.Throws<TaxonomyException>(() => termQuery.SetLocale(null));
+        }
+
+        [Fact]
+        public void TermQuery_IncludeFallback_ReturnsSelfForChaining()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            var result = termQuery.IncludeFallback();
+            Assert.Same(termQuery, result);
+        }
+
+        [Fact]
+        public void TermQuery_IncludeFallback_SetsParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.IncludeFallback();
+
+            var field = typeof(TermQuery).GetField("_queryParams",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);
+            Assert.Equal("true", queryParams["include_fallback"]);
+        }
+
+        [Fact]
+        public void TermQuery_SetLocale_Then_IncludeFallback_ChainsBoth()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms()
+                .SetLocale("hi-in")
+                .IncludeFallback();
+
+            var field = typeof(TermQuery).GetField("_queryParams",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("locale") ?? false);
+            Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);
+        }
+
+        #endregion
+
+        #region Term Constructor Validation Tests
+
+        [Fact]
+        public void Term_WithNullTaxonomyUid_ThrowsTaxonomyException()
+        {
+            Assert.Throws<TaxonomyException>(() =>
+            {
+                var t = typeof(Term)
+                    .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null,
+                        new[] { typeof(ContentstackClient), typeof(string), typeof(string) }, null);
+                try { t?.Invoke(new object[] { _client, null, "smartwatch" }); }
+                catch (System.Reflection.TargetInvocationException ex) { throw ex.InnerException; }
+            });
+        }
+
+        [Fact]
+        public void Term_WithNullTermUid_ThrowsTaxonomyException()
+        {
+            Assert.Throws<TaxonomyException>(() =>
+            {
+                var t = typeof(Term)
+                    .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null,
+                        new[] { typeof(ContentstackClient), typeof(string), typeof(string) }, null);
+                try { t?.Invoke(new object[] { _client, "gadgets", null }); }
+                catch (System.Reflection.TargetInvocationException ex) { throw ex.InnerException; }
+            });
+        }
+
+        #endregion
     }
 }
 

--- a/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
@@ -643,7 +643,7 @@ namespace Contentstack.Core.Unit.Tests
             var termQuery = _client.Taxonomies("gadgets").Terms();
             termQuery.SetLocale("hi-in");
 
-            var field = typeof(TermQuery).GetField("_queryParams",
+            var field = typeof(TermQuery).GetField("UrlQueries",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
 
@@ -652,10 +652,16 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void TermQuery_SetLocale_WithNull_ThrowsTaxonomyException()
+        public void TermQuery_SetLocale_WithNull_DoesNotSetParam()
         {
             var termQuery = _client.Taxonomies("gadgets").Terms();
-            Assert.Throws<TaxonomyException>(() => termQuery.SetLocale(null));
+            termQuery.SetLocale(null);
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.False(urlQueries?.ContainsKey("locale") ?? false);
         }
 
         [Fact]
@@ -672,7 +678,7 @@ namespace Contentstack.Core.Unit.Tests
             var termQuery = _client.Taxonomies("gadgets").Terms();
             termQuery.IncludeFallback();
 
-            var field = typeof(TermQuery).GetField("_queryParams",
+            var field = typeof(TermQuery).GetField("UrlQueries",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
 
@@ -687,9 +693,203 @@ namespace Contentstack.Core.Unit.Tests
                 .SetLocale("hi-in")
                 .IncludeFallback();
 
-            var field = typeof(TermQuery).GetField("_queryParams",
+            var field = typeof(TermQuery).GetField("UrlQueries",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("locale") ?? false);
+            Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);
+        }
+
+        [Fact]
+        public void TermQuery_AddParam_SetsUrlQuery()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.AddParam("custom_key", "custom_value");
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("custom_key") ?? false);
+            Assert.Equal("custom_value", queryParams["custom_key"]);
+        }
+
+        #endregion
+
+        #region Taxonomy.SetLocale / IncludeFallback / AddParam Tests
+
+        [Fact]
+        public void Taxonomy_SetLocale_ReturnsSelfForChaining()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            var result = taxonomy.SetLocale("hi-in");
+            Assert.Same(taxonomy, result);
+        }
+
+        [Fact]
+        public void Taxonomy_SetLocale_SetsUrlQuery()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            taxonomy.SetLocale("hi-in");
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.True(urlQueries?.ContainsKey("locale") ?? false);
+            Assert.Equal("hi-in", urlQueries["locale"]);
+        }
+
+        [Fact]
+        public void Taxonomy_SetLocale_WithNull_DoesNotSetParam()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            taxonomy.SetLocale(null);
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.False(urlQueries?.ContainsKey("locale") ?? false);
+        }
+
+        [Fact]
+        public void Taxonomy_IncludeFallback_ReturnsSelfForChaining()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            var result = taxonomy.IncludeFallback();
+            Assert.Same(taxonomy, result);
+        }
+
+        [Fact]
+        public void Taxonomy_IncludeFallback_SetsUrlQuery()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            taxonomy.IncludeFallback();
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.True(urlQueries?.ContainsKey("include_fallback") ?? false);
+            Assert.Equal("true", urlQueries["include_fallback"]);
+        }
+
+        [Fact]
+        public void Taxonomy_AddParam_SetsUrlQuery()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            taxonomy.AddParam("custom_key", "custom_value");
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.True(urlQueries?.ContainsKey("custom_key") ?? false);
+            Assert.Equal("custom_value", urlQueries["custom_key"]);
+        }
+
+        [Fact]
+        public void Taxonomy_SetLocale_Then_IncludeFallback_ChainsBoth()
+        {
+            var taxonomy = _client.Taxonomies("gadgets")
+                .SetLocale("hi-in")
+                .IncludeFallback();
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.True(urlQueries?.ContainsKey("locale") ?? false);
+            Assert.True(urlQueries?.ContainsKey("include_fallback") ?? false);
+        }
+
+        #endregion
+
+        #region Term.SetLocale / IncludeFallback / AddParam Tests
+
+        [Fact]
+        public void Term_SetLocale_ReturnsSelfForChaining()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            var result = term.SetLocale("hi-in");
+            Assert.Same(term, result);
+        }
+
+        [Fact]
+        public void Term_SetLocale_SetsQueryParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.SetLocale("hi-in");
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("locale") ?? false);
+            Assert.Equal("hi-in", queryParams["locale"]);
+        }
+
+        [Fact]
+        public void Term_SetLocale_WithNull_DoesNotSetParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.SetLocale(null);
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.False(queryParams?.ContainsKey("locale") ?? false);
+        }
+
+        [Fact]
+        public void Term_IncludeFallback_ReturnsSelfForChaining()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            var result = term.IncludeFallback();
+            Assert.Same(term, result);
+        }
+
+        [Fact]
+        public void Term_IncludeFallback_SetsQueryParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.IncludeFallback();
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);
+            Assert.Equal("true", queryParams["include_fallback"]);
+        }
+
+        [Fact]
+        public void Term_AddParam_SetsQueryParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.AddParam("custom_key", "custom_value");
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("custom_key") ?? false);
+            Assert.Equal("custom_value", queryParams["custom_key"]);
+        }
+
+        [Fact]
+        public void Term_SetLocale_Then_IncludeFallback_ChainsBoth()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch")
+                .SetLocale("hi-in")
+                .IncludeFallback();
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
 
             Assert.True(queryParams?.ContainsKey("locale") ?? false);
             Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);

--- a/Contentstack.Core/ContentstackClient.cs
+++ b/Contentstack.Core/ContentstackClient.cs
@@ -609,6 +609,25 @@ namespace Contentstack.Core
         }
 
         /// <summary>
+        /// Returns a <see cref="Taxonomy"/> instance scoped to the given taxonomy UID,
+        /// providing access to published taxonomy data, terms, and locale-aware delivery via the CDA.
+        /// </summary>
+        /// <param name="uid">The UID of the published taxonomy.</param>
+        /// <returns>A <see cref="Taxonomy"/> instance scoped to the given UID.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
+        ///     var taxonomy = await stack.Taxonomies("gadgets").Fetch&lt;MyTaxonomy&gt;();
+        ///     var terms    = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").Find&lt;MyTerm&gt;();
+        ///     var term     = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;("mr-in");
+        /// </code>
+        /// </example>
+        public Taxonomy Taxonomies(string uid)
+        {
+            return new Taxonomy(this, uid);
+        }
+
+        /// <summary>
         /// Get version.
         /// </summary>
         /// <returns>Version</returns>

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -44,13 +44,12 @@ namespace Contentstack.Core.Models
             }
         }
         #endregion
-        public ContentstackClient Stack
+        internal new ContentstackClient Stack
         {
             get;
             set;
         }
 
-       
         #region Internal Constructors
 
         internal Taxonomy()

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -126,10 +126,9 @@ namespace Contentstack.Core.Models
                     mainJson["locale"] = locale;
 
                 var handler = new HttpRequestHandler(Stack);
-                var branch = Stack.Config?.Branch ?? "main";
                 var result = await handler.ProcessRequest(
                     _Url, headerAll, mainJson,
-                    Branch: branch,
+                    Branch: Stack.Config.Branch,
                     timeout: Stack.Config.Timeout,
                     proxy: Stack.Config.Proxy
                 );
@@ -142,7 +141,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using Contentstack.Core.Configuration;
 using Contentstack.Core.Internals;
 using Newtonsoft.Json.Linq;
@@ -16,6 +17,7 @@ namespace Contentstack.Core.Models
         private Dictionary<string, object> _Headers = new Dictionary<string, object>();
         private Dictionary<string, object> _StackHeaders = new Dictionary<string, object>();
         private Dictionary<string, object> UrlQueries = new Dictionary<string, object>();
+        private string _uid = null;
 
         protected override string _Url
         {
@@ -30,6 +32,8 @@ namespace Contentstack.Core.Models
                     throw new TaxonomyException("Taxonomy Stack Config is null. Please ensure the ContentstackClient is properly configured.");
                 }
                 Config config = this.Stack.Config;
+                if (_uid != null)
+                    return String.Format("{0}/taxonomies/{1}", config.BaseUrl, _uid);
                 return String.Format("{0}/taxonomies/entries", config.BaseUrl);
             }
         }
@@ -56,8 +60,91 @@ namespace Contentstack.Core.Models
             this._StackHeaders = stack._LocalHeaders;
         }
 
+        internal Taxonomy(ContentstackClient stack, string uid) : this(stack)
+        {
+            if (string.IsNullOrEmpty(uid))
+                throw new TaxonomyException("Taxonomy UID cannot be null or empty.");
+            _uid = uid;
+        }
+
         #endregion
         #region Public Functions
+
+        /// <summary>
+        /// Returns a Term instance for the given term UID within this taxonomy.
+        /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
+        /// </summary>
+        /// <param name="termUid">The UID of the term to retrieve.</param>
+        /// <returns>A <see cref="Term"/> instance scoped to this taxonomy and term.</returns>
+        public Term Term(string termUid)
+        {
+            if (_uid == null)
+                throw new TaxonomyException("Term() requires a taxonomy UID. Use client.Taxonomies(\"uid\") to scope to a specific taxonomy.");
+            return new Term(Stack, _uid, termUid);
+        }
+
+        /// <summary>
+        /// Returns a TermQuery for listing all published terms within this taxonomy.
+        /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
+        /// </summary>
+        /// <returns>A <see cref="TermQuery"/> instance for this taxonomy.</returns>
+        public TermQuery Terms()
+        {
+            if (_uid == null)
+                throw new TaxonomyException("Terms() requires a taxonomy UID. Use client.Taxonomies(\"uid\") to scope to a specific taxonomy.");
+            return new TermQuery(Stack, _uid);
+        }
+
+        /// <summary>
+        /// Fetches the published taxonomy by its UID from the CDA.
+        /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
+        /// </summary>
+        /// <param name="locale">Optional locale code (e.g. "hi-in"). Omit for the master locale.</param>
+        /// <returns>The deserialized taxonomy object.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
+        ///     var taxonomy = await stack.Taxonomies("gadgets").Fetch&lt;MyTaxonomy&gt;();
+        ///     var localized = await stack.Taxonomies("gadgets").Fetch&lt;MyTaxonomy&gt;("hi-in");
+        /// </code>
+        /// </example>
+        public async System.Threading.Tasks.Task<T> Fetch<T>(string locale = null)
+        {
+            if (_uid == null)
+                throw new TaxonomyException("Fetch() requires a taxonomy UID. Use client.Taxonomies(\"uid\") to scope to a specific taxonomy.");
+
+            try
+            {
+                var headerAll = new Dictionary<string, object>();
+                foreach (var header in Stack._LocalHeaders)
+                    headerAll[header.Key] = header.Value;
+
+                var mainJson = new Dictionary<string, object>();
+                if (Stack.Config?.Environment != null)
+                    mainJson["environment"] = Stack.Config.Environment;
+                if (!string.IsNullOrEmpty(locale))
+                    mainJson["locale"] = locale;
+
+                var handler = new HttpRequestHandler(Stack);
+                var branch = Stack.Config?.Branch ?? "main";
+                var result = await handler.ProcessRequest(
+                    _Url, headerAll, mainJson,
+                    Branch: branch,
+                    timeout: Stack.Config.Timeout,
+                    proxy: Stack.Config.Proxy
+                );
+
+                var jObject = Newtonsoft.Json.Linq.JObject.Parse(result);
+                var token = jObject.SelectToken("$.taxonomy");
+                if (token != null)
+                    return token.ToObject<T>(Stack.Serializer);
+                return jObject.ToObject<T>(Stack.Serializer);
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
 
         /// <summary>
         /// Add a constraint to the query that requires a particular key entry to be less than the provided value.

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -9,6 +9,12 @@ using Newtonsoft.Json.Linq;
 
 namespace Contentstack.Core.Models
 {
+    /// <summary>
+    /// Represents a published taxonomy from the CDA, providing methods to fetch the taxonomy,
+    /// list its terms, and navigate to individual terms.
+    /// Use <see cref="SetLocale"/>, <see cref="IncludeFallback"/>, and <see cref="AddParam"/> to
+    /// configure the request before calling <see cref="Fetch{T}"/>.
+    /// </summary>
     public class Taxonomy: Query
     {
 
@@ -71,11 +77,67 @@ namespace Contentstack.Core.Models
         #region Public Functions
 
         /// <summary>
+        /// Sets the locale for this taxonomy fetch.
+        /// Passing null or empty is a no-op.
+        /// </summary>
+        /// <param name="locale">Locale code (e.g. "hi-in", "en-us").</param>
+        /// <returns>The current <see cref="Taxonomy"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var taxonomy = await stack.Taxonomies("gadgets").SetLocale("hi-in").Fetch&lt;MyTaxonomy&gt;();
+        /// </code>
+        /// </example>
+        public new Taxonomy SetLocale(string locale)
+        {
+            if (!string.IsNullOrEmpty(locale))
+                UrlQueries["locale"] = locale;
+            return this;
+        }
+
+        /// <summary>
+        /// Falls back to the master locale when the taxonomy is not published in the requested locale.
+        /// Can be used with or without <see cref="SetLocale"/>.
+        /// </summary>
+        /// <returns>The current <see cref="Taxonomy"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var taxonomy = await stack.Taxonomies("gadgets").SetLocale("hi-in").IncludeFallback().Fetch&lt;MyTaxonomy&gt;();
+        /// </code>
+        /// </example>
+        public new Taxonomy IncludeFallback()
+        {
+            UrlQueries["include_fallback"] = "true";
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom query parameter to the request.
+        /// </summary>
+        /// <param name="key">Parameter key.</param>
+        /// <param name="value">Parameter value.</param>
+        /// <returns>The current <see cref="Taxonomy"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var taxonomy = await stack.Taxonomies("gadgets").AddParam("include_branch", "true").Fetch&lt;MyTaxonomy&gt;();
+        /// </code>
+        /// </example>
+        public new Taxonomy AddParam(string key, string value)
+        {
+            UrlQueries[key] = value;
+            return this;
+        }
+
+        /// <summary>
         /// Returns a Term instance for the given term UID within this taxonomy.
         /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
         /// </summary>
         /// <param name="termUid">The UID of the term to retrieve.</param>
         /// <returns>A <see cref="Term"/> instance scoped to this taxonomy and term.</returns>
+        /// <example>
+        /// <code>
+        ///     var term = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
         public Term Term(string termUid)
         {
             if (_uid == null)
@@ -88,6 +150,11 @@ namespace Contentstack.Core.Models
         /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
         /// </summary>
         /// <returns>A <see cref="TermQuery"/> instance for this taxonomy.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
         public TermQuery Terms()
         {
             if (_uid == null)
@@ -98,17 +165,18 @@ namespace Contentstack.Core.Models
         /// <summary>
         /// Fetches the published taxonomy by its UID from the CDA.
         /// Requires the Taxonomy to be initialised with a UID via <c>client.Taxonomies("uid")</c>.
+        /// Use <see cref="SetLocale"/> and <see cref="IncludeFallback"/> to set query parameters before calling.
         /// </summary>
-        /// <param name="locale">Optional locale code (e.g. "hi-in"). Omit for the master locale.</param>
         /// <returns>The deserialized taxonomy object.</returns>
         /// <example>
         /// <code>
         ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
         ///     var taxonomy = await stack.Taxonomies("gadgets").Fetch&lt;MyTaxonomy&gt;();
-        ///     var localized = await stack.Taxonomies("gadgets").Fetch&lt;MyTaxonomy&gt;("hi-in");
+        ///     var localized = await stack.Taxonomies("gadgets").SetLocale("hi-in").Fetch&lt;MyTaxonomy&gt;();
+        ///     var withFallback = await stack.Taxonomies("gadgets").SetLocale("hi-in").IncludeFallback().Fetch&lt;MyTaxonomy&gt;();
         /// </code>
         /// </example>
-        public async System.Threading.Tasks.Task<T> Fetch<T>(string locale = null)
+        public async Task<T> Fetch<T>()
         {
             if (_uid == null)
                 throw new TaxonomyException("Fetch() requires a taxonomy UID. Use client.Taxonomies(\"uid\") to scope to a specific taxonomy.");
@@ -122,8 +190,8 @@ namespace Contentstack.Core.Models
                 var mainJson = new Dictionary<string, object>();
                 if (Stack.Config?.Environment != null)
                     mainJson["environment"] = Stack.Config.Environment;
-                if (!string.IsNullOrEmpty(locale))
-                    mainJson["locale"] = locale;
+                foreach (var kvp in UrlQueries)
+                    mainJson[kvp.Key] = kvp.Value;
 
                 var handler = new HttpRequestHandler(Stack);
                 var result = await handler.ProcessRequest(
@@ -346,7 +414,7 @@ namespace Contentstack.Core.Models
                 return _StackHeaders;
             }
         }
-        internal static ContentstackException GetContentstackError(Exception ex)
+        internal new static ContentstackException GetContentstackError(Exception ex)
         {
             Int32 errorCode = 0;
             string errorMessage = string.Empty;

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Contentstack.Core.Internals;
+using Newtonsoft.Json.Linq;
+
+namespace Contentstack.Core.Models
+{
+    /// <summary>
+    /// Represents a single published term within a taxonomy, providing methods to fetch
+    /// the term, its localized versions, ancestors, and descendants from the CDA.
+    /// </summary>
+    public class Term
+    {
+        private readonly ContentstackClient _stack;
+        private readonly string _taxonomyUid;
+        private readonly string _termUid;
+
+        private string BaseUrlPath =>
+            $"{_stack.Config.BaseUrl}/taxonomies/{_taxonomyUid}/terms/{_termUid}";
+
+        internal Term(ContentstackClient stack, string taxonomyUid, string termUid)
+        {
+            _stack = stack ?? throw new TaxonomyException("ContentstackClient cannot be null when creating a Term instance.");
+            if (string.IsNullOrEmpty(taxonomyUid)) throw new TaxonomyException("taxonomyUid cannot be null or empty.");
+            if (string.IsNullOrEmpty(termUid))     throw new TaxonomyException("termUid cannot be null or empty.");
+            _taxonomyUid = taxonomyUid;
+            _termUid = termUid;
+        }
+
+        /// <summary>
+        /// Fetches the published term from the CDA.
+        /// </summary>
+        /// <param name="locale">Optional locale code (e.g. "mr-in"). Omit for the master locale.</param>
+        /// <returns>The deserialized term object.</returns>
+        /// <example>
+        /// <code>
+        ///     var term           = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;();
+        ///     var localizedTerm  = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;("mr-in");
+        /// </code>
+        /// </example>
+        public async Task<T> Fetch<T>(string locale = null)
+        {
+            try
+            {
+                var queryParams = new Dictionary<string, object>();
+                if (!string.IsNullOrEmpty(locale))
+                    queryParams["locale"] = locale;
+
+                var result = await ExecuteRequest(BaseUrlPath, queryParams);
+                var jObject = JObject.Parse(result);
+                var token = jObject.SelectToken("$.term");
+                if (token != null)
+                    return token.ToObject<T>(_stack.Serializer);
+                return jObject.ToObject<T>(_stack.Serializer);
+            }
+            catch (TaxonomyException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all published, localized versions of this term across every locale.
+        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/locales.
+        /// </summary>
+        /// <returns>The deserialized locales collection.</returns>
+        /// <example>
+        /// <code>
+        ///     var locales = await stack.Taxonomies("gadgets").Term("smartwatch").Locales&lt;MyLocales&gt;();
+        /// </code>
+        /// </example>
+        public async Task<T> Locales<T>()
+        {
+            try
+            {
+                var result = await ExecuteRequest($"{BaseUrlPath}/locales");
+                var jObject = JObject.Parse(result);
+                var token = jObject.SelectToken("$.locales");
+                if (token != null)
+                    return token.ToObject<T>(_stack.Serializer);
+                return jObject.ToObject<T>(_stack.Serializer);
+            }
+            catch (TaxonomyException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all ancestors of this term up to the root.
+        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/ancestors.
+        /// </summary>
+        /// <returns>The deserialized ancestors collection.</returns>
+        /// <example>
+        /// <code>
+        ///     var ancestors = await stack.Taxonomies("gadgets").Term("smartwatch").Ancestors&lt;MyTerms&gt;();
+        /// </code>
+        /// </example>
+        public async Task<T> Ancestors<T>()
+        {
+            try
+            {
+                var result = await ExecuteRequest($"{BaseUrlPath}/ancestors");
+                var jObject = JObject.Parse(result);
+                var token = jObject.SelectToken("$.ancestors");
+                if (token != null)
+                    return token.ToObject<T>(_stack.Serializer);
+                return jObject.ToObject<T>(_stack.Serializer);
+            }
+            catch (TaxonomyException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all descendants of this term.
+        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/descendants.
+        /// </summary>
+        /// <returns>The deserialized descendants collection.</returns>
+        /// <example>
+        /// <code>
+        ///     var descendants = await stack.Taxonomies("gadgets").Term("smartwatch").Descendants&lt;MyTerms&gt;();
+        /// </code>
+        /// </example>
+        public async Task<T> Descendants<T>()
+        {
+            try
+            {
+                var result = await ExecuteRequest($"{BaseUrlPath}/descendants");
+                var jObject = JObject.Parse(result);
+                var token = jObject.SelectToken("$.descendants");
+                if (token != null)
+                    return token.ToObject<T>(_stack.Serializer);
+                return jObject.ToObject<T>(_stack.Serializer);
+            }
+            catch (TaxonomyException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
+
+        private async Task<string> ExecuteRequest(string url, Dictionary<string, object> extraParams = null)
+        {
+            var headerAll = new Dictionary<string, object>();
+            foreach (var header in _stack._LocalHeaders)
+                headerAll[header.Key] = header.Value;
+
+            var mainJson = new Dictionary<string, object>();
+            if (_stack.Config?.Environment != null)
+                mainJson["environment"] = _stack.Config.Environment;
+
+            if (extraParams != null)
+                foreach (var param in extraParams)
+                    mainJson[param.Key] = param.Value;
+
+            var handler = new HttpRequestHandler(_stack);
+            var branch = _stack.Config?.Branch ?? "main";
+            return await handler.ProcessRequest(
+                url, headerAll, mainJson,
+                Branch: branch,
+                timeout: _stack.Config.Timeout,
+                proxy: _stack.Config.Proxy
+            );
+        }
+    }
+}

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -60,7 +60,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -91,7 +97,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -122,7 +134,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -153,7 +171,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -172,10 +196,9 @@ namespace Contentstack.Core.Models
                     mainJson[param.Key] = param.Value;
 
             var handler = new HttpRequestHandler(_stack);
-            var branch = _stack.Config?.Branch ?? "main";
             return await handler.ProcessRequest(
                 url, headerAll, mainJson,
-                Branch: branch,
+                Branch: _stack.Config.Branch,
                 timeout: _stack.Config.Timeout,
                 proxy: _stack.Config.Proxy
             );

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -32,20 +32,24 @@ namespace Contentstack.Core.Models
         /// Fetches the published term from the CDA.
         /// </summary>
         /// <param name="locale">Optional locale code (e.g. "mr-in"). Omit for the master locale.</param>
+        /// <param name="includeFallback">When true, falls back to the master locale if the term has no localized version.</param>
         /// <returns>The deserialized term object.</returns>
         /// <example>
         /// <code>
         ///     var term           = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;();
         ///     var localizedTerm  = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;("mr-in");
+        ///     var withFallback   = await stack.Taxonomies("gadgets").Term("laptop").Fetch&lt;MyTerm&gt;("hi-in", includeFallback: true);
         /// </code>
         /// </example>
-        public async Task<T> Fetch<T>(string locale = null)
+        public async Task<T> Fetch<T>(string locale = null, bool includeFallback = false)
         {
             try
             {
                 var queryParams = new Dictionary<string, object>();
                 if (!string.IsNullOrEmpty(locale))
                     queryParams["locale"] = locale;
+                if (includeFallback)
+                    queryParams["include_fallback"] = "true";
 
                 var result = await ExecuteRequest(BaseUrlPath, queryParams);
                 var jObject = JObject.Parse(result);

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -9,12 +9,15 @@ namespace Contentstack.Core.Models
     /// <summary>
     /// Represents a single published term within a taxonomy, providing methods to fetch
     /// the term, its localized versions, ancestors, and descendants from the CDA.
+    /// Use <see cref="SetLocale"/>, <see cref="IncludeFallback"/>, and <see cref="AddParam"/> to
+    /// configure the request before calling <see cref="Fetch{T}"/>.
     /// </summary>
     public class Term
     {
         private readonly ContentstackClient _stack;
         private readonly string _taxonomyUid;
         private readonly string _termUid;
+        private readonly Dictionary<string, object> UrlQueries = new Dictionary<string, object>();
 
         private string BaseUrlPath =>
             $"{_stack.Config.BaseUrl}/taxonomies/{_taxonomyUid}/terms/{_termUid}";
@@ -29,29 +32,73 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
-        /// Fetches the published term from the CDA.
+        /// Sets the locale for this term fetch.
+        /// Passing null or empty is a no-op.
         /// </summary>
-        /// <param name="locale">Optional locale code (e.g. "mr-in"). Omit for the master locale.</param>
-        /// <param name="includeFallback">When true, falls back to the master locale if the term has no localized version.</param>
+        /// <param name="locale">Locale code (e.g. "hi-in", "en-us").</param>
+        /// <returns>The current <see cref="Term"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var term = await stack.Taxonomies("gadgets").Term("smartwatch").SetLocale("hi-in").Fetch&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public Term SetLocale(string locale)
+        {
+            if (!string.IsNullOrEmpty(locale))
+                UrlQueries["locale"] = locale;
+            return this;
+        }
+
+        /// <summary>
+        /// Falls back to the master locale when the term is not published in the requested locale.
+        /// Can be used with or without <see cref="SetLocale"/>.
+        /// </summary>
+        /// <returns>The current <see cref="Term"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var term = await stack.Taxonomies("gadgets").Term("smartwatch").SetLocale("hi-in").IncludeFallback().Fetch&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public Term IncludeFallback()
+        {
+            UrlQueries["include_fallback"] = "true";
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom query parameter to the request.
+        /// </summary>
+        /// <param name="key">Parameter key.</param>
+        /// <param name="value">Parameter value.</param>
+        /// <returns>The current <see cref="Term"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var term = await stack.Taxonomies("gadgets").Term("smartwatch").AddParam("include_branch", "true").Fetch&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public Term AddParam(string key, string value)
+        {
+            UrlQueries[key] = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Fetches the published term from the CDA.
+        /// Maps to GET /v3/taxonomies/{uid}/terms/{termUid} with any configured query parameters.
+        /// </summary>
         /// <returns>The deserialized term object.</returns>
         /// <example>
         /// <code>
-        ///     var term           = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;();
-        ///     var localizedTerm  = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;("mr-in");
-        ///     var withFallback   = await stack.Taxonomies("gadgets").Term("laptop").Fetch&lt;MyTerm&gt;("hi-in", includeFallback: true);
+        ///     var term         = await stack.Taxonomies("gadgets").Term("smartwatch").Fetch&lt;MyTerm&gt;();
+        ///     var localized    = await stack.Taxonomies("gadgets").Term("smartwatch").SetLocale("hi-in").Fetch&lt;MyTerm&gt;();
+        ///     var withFallback = await stack.Taxonomies("gadgets").Term("smartwatch").SetLocale("hi-in").IncludeFallback().Fetch&lt;MyTerm&gt;();
         /// </code>
         /// </example>
-        public async Task<T> Fetch<T>(string locale = null, bool includeFallback = false)
+        public async Task<T> Fetch<T>()
         {
             try
             {
-                var queryParams = new Dictionary<string, object>();
-                if (!string.IsNullOrEmpty(locale))
-                    queryParams["locale"] = locale;
-                if (includeFallback)
-                    queryParams["include_fallback"] = "true";
-
-                var result = await ExecuteRequest(BaseUrlPath, queryParams);
+                var result = await ExecuteRequest(BaseUrlPath, UrlQueries);
                 var jObject = JObject.Parse(result);
                 var token = jObject.SelectToken("$.term");
                 if (token != null)
@@ -75,13 +122,13 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
-        /// Fetches all published, localized versions of this term across every locale.
-        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/locales.
+        /// Fetches all published localized versions of this term across every locale.
+        /// Maps to GET /v3/taxonomies/{uid}/terms/{termUid}/locales.
         /// </summary>
         /// <returns>The deserialized locales collection.</returns>
         /// <example>
         /// <code>
-        ///     var locales = await stack.Taxonomies("gadgets").Term("smartwatch").Locales&lt;MyLocales&gt;();
+        ///     var locales = await stack.Taxonomies("gadgets").Term("smartwatch").Locales&lt;JToken&gt;();
         /// </code>
         /// </example>
         public async Task<T> Locales<T>()
@@ -112,13 +159,13 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
-        /// Fetches all ancestors of this term up to the root.
-        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/ancestors.
+        /// Fetches all ancestors of this term up to the taxonomy root.
+        /// Maps to GET /v3/taxonomies/{uid}/terms/{termUid}/ancestors.
         /// </summary>
         /// <returns>The deserialized ancestors collection.</returns>
         /// <example>
         /// <code>
-        ///     var ancestors = await stack.Taxonomies("gadgets").Term("smartwatch").Ancestors&lt;MyTerms&gt;();
+        ///     var ancestors = await stack.Taxonomies("gadgets").Term("smartwatch").Ancestors&lt;JToken&gt;();
         /// </code>
         /// </example>
         public async Task<T> Ancestors<T>()
@@ -150,12 +197,12 @@ namespace Contentstack.Core.Models
 
         /// <summary>
         /// Fetches all descendants of this term.
-        /// Maps to GET /taxonomies/{uid}/terms/{termUid}/descendants.
+        /// Maps to GET /v3/taxonomies/{uid}/terms/{termUid}/descendants.
         /// </summary>
         /// <returns>The deserialized descendants collection.</returns>
         /// <example>
         /// <code>
-        ///     var descendants = await stack.Taxonomies("gadgets").Term("smartwatch").Descendants&lt;MyTerms&gt;();
+        ///     var descendants = await stack.Taxonomies("gadgets").Term("smartwatch").Descendants&lt;JToken&gt;();
         /// </code>
         /// </example>
         public async Task<T> Descendants<T>()
@@ -196,8 +243,8 @@ namespace Contentstack.Core.Models
                 mainJson["environment"] = _stack.Config.Environment;
 
             if (extraParams != null)
-                foreach (var param in extraParams)
-                    mainJson[param.Key] = param.Value;
+                foreach (var kvp in extraParams)
+                    mainJson[kvp.Key] = kvp.Value;
 
             var handler = new HttpRequestHandler(_stack);
             return await handler.ProcessRequest(

--- a/Contentstack.Core/Models/TermQuery.cs
+++ b/Contentstack.Core/Models/TermQuery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Contentstack.Core.Internals;
 using Newtonsoft.Json.Linq;
@@ -87,10 +88,9 @@ namespace Contentstack.Core.Models
                     mainJson[param.Key] = param.Value;
 
                 var handler = new HttpRequestHandler(_stack);
-                var branch = _stack.Config?.Branch ?? "main";
                 var result = await handler.ProcessRequest(
                     Url, headerAll, mainJson,
-                    Branch: branch,
+                    Branch: _stack.Config.Branch,
                     timeout: _stack.Config.Timeout,
                     proxy: _stack.Config.Proxy
                 );
@@ -98,7 +98,7 @@ namespace Contentstack.Core.Models
                 var jObject = JObject.Parse(result);
                 var terms = jObject.SelectToken("$.terms")?.ToObject<IEnumerable<T>>(_stack.Serializer);
                 var collection = jObject.ToObject<ContentstackCollection<T>>(_stack.Serializer);
-                collection.Items = terms ?? new List<T>();
+                collection.Items = terms ?? Enumerable.Empty<T>();
                 return collection;
             }
             catch (TaxonomyException)
@@ -107,7 +107,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
     }

--- a/Contentstack.Core/Models/TermQuery.cs
+++ b/Contentstack.Core/Models/TermQuery.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Contentstack.Core.Internals;
+using Newtonsoft.Json.Linq;
+
+namespace Contentstack.Core.Models
+{
+    /// <summary>
+    /// Provides a fluent query builder for listing published terms within a taxonomy from the CDA.
+    /// Supports locale filtering and master-locale fallback.
+    /// </summary>
+    public class TermQuery
+    {
+        private readonly ContentstackClient _stack;
+        private readonly string _taxonomyUid;
+        private readonly Dictionary<string, object> _queryParams = new Dictionary<string, object>();
+
+        private string Url =>
+            $"{_stack.Config.BaseUrl}/taxonomies/{_taxonomyUid}/terms";
+
+        internal TermQuery(ContentstackClient stack, string taxonomyUid)
+        {
+            _stack = stack ?? throw new TaxonomyException("ContentstackClient cannot be null when creating a TermQuery instance.");
+            if (string.IsNullOrEmpty(taxonomyUid)) throw new TaxonomyException("taxonomyUid cannot be null or empty.");
+            _taxonomyUid = taxonomyUid;
+        }
+
+        /// <summary>
+        /// Filters terms to those published in the specified locale.
+        /// </summary>
+        /// <param name="locale">The locale code (e.g. "hi-in", "en-us").</param>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery SetLocale(string locale)
+        {
+            if (string.IsNullOrEmpty(locale))
+                throw new TaxonomyException("Locale cannot be null or empty.");
+            _queryParams["locale"] = locale;
+            return this;
+        }
+
+        /// <summary>
+        /// When a term is not localized in the requested locale, falls back to the master locale.
+        /// Must be used together with <see cref="SetLocale"/>.
+        /// </summary>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").IncludeFallback().Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery IncludeFallback()
+        {
+            _queryParams["include_fallback"] = "true";
+            return this;
+        }
+
+        /// <summary>
+        /// Executes the query and returns all matching published terms.
+        /// Maps to GET /taxonomies/{uid}/terms with any configured locale and fallback params.
+        /// </summary>
+        /// <returns>A <see cref="ContentstackCollection{T}"/> containing the matched terms.</returns>
+        /// <example>
+        /// <code>
+        ///     var result = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").IncludeFallback().Find&lt;MyTerm&gt;();
+        ///     foreach (var term in result) { ... }
+        /// </code>
+        /// </example>
+        public async Task<ContentstackCollection<T>> Find<T>()
+        {
+            try
+            {
+                var headerAll = new Dictionary<string, object>();
+                foreach (var header in _stack._LocalHeaders)
+                    headerAll[header.Key] = header.Value;
+
+                var mainJson = new Dictionary<string, object>();
+                if (_stack.Config?.Environment != null)
+                    mainJson["environment"] = _stack.Config.Environment;
+
+                foreach (var param in _queryParams)
+                    mainJson[param.Key] = param.Value;
+
+                var handler = new HttpRequestHandler(_stack);
+                var branch = _stack.Config?.Branch ?? "main";
+                var result = await handler.ProcessRequest(
+                    Url, headerAll, mainJson,
+                    Branch: branch,
+                    timeout: _stack.Config.Timeout,
+                    proxy: _stack.Config.Proxy
+                );
+
+                var jObject = JObject.Parse(result);
+                var terms = jObject.SelectToken("$.terms")?.ToObject<IEnumerable<T>>(_stack.Serializer);
+                var collection = jObject.ToObject<ContentstackCollection<T>>(_stack.Serializer);
+                collection.Items = terms ?? new List<T>();
+                return collection;
+            }
+            catch (TaxonomyException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TaxonomyException.CreateForProcessingError(ex);
+            }
+        }
+    }
+}

--- a/Contentstack.Core/Models/TermQuery.cs
+++ b/Contentstack.Core/Models/TermQuery.cs
@@ -9,13 +9,14 @@ namespace Contentstack.Core.Models
 {
     /// <summary>
     /// Provides a fluent query builder for listing published terms within a taxonomy from the CDA.
-    /// Supports locale filtering and master-locale fallback.
+    /// Use <see cref="SetLocale"/>, <see cref="IncludeFallback"/>, and <see cref="AddParam"/> to
+    /// configure the request before calling <see cref="Find{T}"/>.
     /// </summary>
     public class TermQuery
     {
         private readonly ContentstackClient _stack;
         private readonly string _taxonomyUid;
-        private readonly Dictionary<string, object> _queryParams = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> UrlQueries = new Dictionary<string, object>();
 
         private string Url =>
             $"{_stack.Config.BaseUrl}/taxonomies/{_taxonomyUid}/terms";
@@ -29,8 +30,9 @@ namespace Contentstack.Core.Models
 
         /// <summary>
         /// Filters terms to those published in the specified locale.
+        /// Passing null or empty is a no-op.
         /// </summary>
-        /// <param name="locale">The locale code (e.g. "hi-in", "en-us").</param>
+        /// <param name="locale">Locale code (e.g. "hi-in", "en-us").</param>
         /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
         /// <example>
         /// <code>
@@ -39,15 +41,14 @@ namespace Contentstack.Core.Models
         /// </example>
         public TermQuery SetLocale(string locale)
         {
-            if (string.IsNullOrEmpty(locale))
-                throw new TaxonomyException("Locale cannot be null or empty.");
-            _queryParams["locale"] = locale;
+            if (!string.IsNullOrEmpty(locale))
+                UrlQueries["locale"] = locale;
             return this;
         }
 
         /// <summary>
-        /// When a term is not localized in the requested locale, falls back to the master locale.
-        /// Must be used together with <see cref="SetLocale"/>.
+        /// Falls back to the master locale when a term is not published in the requested locale.
+        /// Can be used with or without <see cref="SetLocale"/>.
         /// </summary>
         /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
         /// <example>
@@ -57,19 +58,36 @@ namespace Contentstack.Core.Models
         /// </example>
         public TermQuery IncludeFallback()
         {
-            _queryParams["include_fallback"] = "true";
+            UrlQueries["include_fallback"] = "true";
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom query parameter to the request.
+        /// </summary>
+        /// <param name="key">Parameter key.</param>
+        /// <param name="value">Parameter value.</param>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().AddParam("depth", "2").Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery AddParam(string key, string value)
+        {
+            UrlQueries[key] = value;
             return this;
         }
 
         /// <summary>
         /// Executes the query and returns all matching published terms.
-        /// Maps to GET /taxonomies/{uid}/terms with any configured locale and fallback params.
+        /// Maps to GET /v3/taxonomies/{uid}/terms with any configured query parameters.
         /// </summary>
         /// <returns>A <see cref="ContentstackCollection{T}"/> containing the matched terms.</returns>
         /// <example>
         /// <code>
         ///     var result = await stack.Taxonomies("gadgets").Terms().SetLocale("hi-in").IncludeFallback().Find&lt;MyTerm&gt;();
-        ///     foreach (var term in result) { ... }
+        ///     foreach (var term in result.Items) { ... }
         /// </code>
         /// </example>
         public async Task<ContentstackCollection<T>> Find<T>()
@@ -84,8 +102,8 @@ namespace Contentstack.Core.Models
                 if (_stack.Config?.Environment != null)
                     mainJson["environment"] = _stack.Config.Environment;
 
-                foreach (var param in _queryParams)
-                    mainJson[param.Key] = param.Value;
+                foreach (var kvp in UrlQueries)
+                    mainJson[kvp.Key] = kvp.Value;
 
                 var handler = new HttpRequestHandler(_stack);
                 var result = await handler.ProcessRequest(

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.28.0</Version>
+    <Version>2.29.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Extends the .NET SDK with published-taxonomy fetch and term delivery endpoints to match the TypeScript feat/taxonomy-publishing parity.

New:
- Term.cs — Fetch(locale?), Locales<T>(), Ancestors<T>(), Descendants<T>()
- TermQuery.cs — SetLocale()/IncludeFallback() chainable builder + Find<T>()

Extended Taxonomy class:
- Taxonomy(stack, uid) constructor
- _Url switches to /taxonomies/{uid} when uid is set
- Fetch<T>(locale?) — own HTTP path, parses $.taxonomy
- Term(termUid) → Term, Terms() → TermQuery

Extended ContentstackClient:
- Taxonomies(uid) overload

Tests:
- TaxonomyUnitTests — 46 unit tests (all pass)
- TaxonomyLocalisationTest — integration tests per CDA call
- TestDataHelper — taxonomy-publish stack config properties