### PR TITLE
fix: added branch set via the stack config

### DIFF
--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -141,7 +141,6 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             LogAssert("Verifying response");
             Assert.NotNull(result);
             Assert.NotNull(result.Items);
-            // Fallback means we should get at least as many terms as without fallback
             Assert.True(result.Items.Any());
         }
 

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -126,10 +126,9 @@ namespace Contentstack.Core.Models
                     mainJson["locale"] = locale;
 
                 var handler = new HttpRequestHandler(Stack);
-                var branch = Stack.Config?.Branch ?? "main";
                 var result = await handler.ProcessRequest(
                     _Url, headerAll, mainJson,
-                    Branch: branch,
+                    Branch: Stack.Config.Branch,
                     timeout: Stack.Config.Timeout,
                     proxy: Stack.Config.Proxy
                 );
@@ -142,7 +141,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -60,7 +60,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -91,7 +97,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -122,7 +134,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -153,7 +171,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
 
@@ -172,10 +196,9 @@ namespace Contentstack.Core.Models
                     mainJson[param.Key] = param.Value;
 
             var handler = new HttpRequestHandler(_stack);
-            var branch = _stack.Config?.Branch ?? "main";
             return await handler.ProcessRequest(
                 url, headerAll, mainJson,
-                Branch: branch,
+                Branch: _stack.Config.Branch,
                 timeout: _stack.Config.Timeout,
                 proxy: _stack.Config.Proxy
             );

--- a/Contentstack.Core/Models/TermQuery.cs
+++ b/Contentstack.Core/Models/TermQuery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Contentstack.Core.Internals;
 using Newtonsoft.Json.Linq;
@@ -87,10 +88,9 @@ namespace Contentstack.Core.Models
                     mainJson[param.Key] = param.Value;
 
                 var handler = new HttpRequestHandler(_stack);
-                var branch = _stack.Config?.Branch ?? "main";
                 var result = await handler.ProcessRequest(
                     Url, headerAll, mainJson,
-                    Branch: branch,
+                    Branch: _stack.Config.Branch,
                     timeout: _stack.Config.Timeout,
                     proxy: _stack.Config.Proxy
                 );
@@ -98,7 +98,7 @@ namespace Contentstack.Core.Models
                 var jObject = JObject.Parse(result);
                 var terms = jObject.SelectToken("$.terms")?.ToObject<IEnumerable<T>>(_stack.Serializer);
                 var collection = jObject.ToObject<ContentstackCollection<T>>(_stack.Serializer);
-                collection.Items = terms ?? new List<T>();
+                collection.Items = terms ?? Enumerable.Empty<T>();
                 return collection;
             }
             catch (TaxonomyException)
@@ -107,7 +107,13 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                throw TaxonomyException.CreateForProcessingError(ex);
+                var contentstackError = Taxonomy.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
             }
         }
     }


### PR DESCRIPTION

## Summary

Two bugs in the taxonomy localisation implementation introduced in `feat: add localized taxonomy and term delivery (CDA) support`:

1. **Branch fallback `?? "main"` breaks non-branched stacks** — every request injected `branch=main` when `Config.Branch` was null, causing `422 Branch not found` on any stack without branching configured.
2. **4xx API errors lose structured detail** — `TaxonomyException.CreateForProcessingError(ex)` wrapped the raw exception without reading the API response body, leaving `ErrorCode`, `StatusCode`, and `Errors` always at their zero/null defaults.

---

## Files Changed

| File | Changes |
|---|---|
| `Contentstack.Core/Models/Taxonomy.cs` | Remove `?? "main"` branch fallback; wire `GetContentstackError()` into catch block |
| `Contentstack.Core/Models/Term.cs` | Remove `?? "main"` branch fallback in `ExecuteRequest`; wire `GetContentstackError()` in all four catch blocks (`Fetch`, `Locales`, `Ancestors`, `Descendants`) |
| `Contentstack.Core/Models/TermQuery.cs` | Remove `?? "main"` branch fallback; wire `GetContentstackError()` into catch block; swap `new List<T>()` empty fallback for `Enumerable.Empty<T>()` |
| `Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs` | Remove one stale assertion that was checking removed behaviour |

---

## Bug 1 — Branch fallback `?? "main"`

### Before

```csharp
// Taxonomy.cs, Term.cs, TermQuery.cs — all three
var branch = Stack.Config?.Branch ?? "main";
var result = await handler.ProcessRequest(_Url, headerAll, mainJson, Branch: branch, ...);
```

### After

```csharp
var result = await handler.ProcessRequest(_Url, headerAll, mainJson, Branch: Stack.Config.Branch, ...);
```

### Why it broke

When a stack is created without branching configured, `Config.Branch` is `null`. `HttpRequestHandler.ProcessRequest` omits the `branch` header when passed `null` — correct behaviour. The `?? "main"` fallback bypassed that and sent `branch=main` on every request. Any stack that does not have a branch named `"main"` got a `422 Branch not found` back from the CDA.

`Asset` and `Entry` pass `Config.Branch` directly with no fallback. This change aligns taxonomy with that pattern.

---

## Bug 2 — Structured error propagation

### Before

```csharp
catch (Exception ex)
{
    throw TaxonomyException.CreateForProcessingError(ex);
}
```

`CreateForProcessingError` does this:

```csharp
public static TaxonomyException CreateForProcessingError(Exception innerException)
{
    return new TaxonomyException(
        string.Format(ErrorMessages.TaxonomyProcessingError,
        ErrorMessages.FormatExceptionDetails(innerException)),
        innerException);
}
```

It formats the exception message string and wraps it. It never reads the HTTP response body. So on a `401` or `422`, callers got:

```
TaxonomyException.ErrorCode   → 0
TaxonomyException.StatusCode  → 500
TaxonomyException.Errors      → null
TaxonomyException.Message     → "An error occurred while processing the Taxonomy: The remote server returned an error: (401) Unauthorized."
```

### After

```csharp
catch (Exception ex)
{
    var contentstackError = GetContentstackError(ex);         // Taxonomy.cs
    // var contentstackError = Taxonomy.GetContentstackError(ex); // Term.cs, TermQuery.cs
    throw new TaxonomyException(contentstackError.Message, ex)
    {
        ErrorCode  = contentstackError.ErrorCode,
        StatusCode = contentstackError.StatusCode,
        Errors     = contentstackError.Errors
    };
}
```

`GetContentstackError(ex)` was already present on `Taxonomy` — identical to the implementation on `Asset` and `Entry`. It opens the `WebException` response stream, reads the JSON body, and extracts `error_code`, `error_message`, and `errors`. Callers now get:

```
TaxonomyException.ErrorCode   → 105
TaxonomyException.StatusCode  → 401
TaxonomyException.Errors      → { "api_key": "is not valid" }
TaxonomyException.Message     → "Access denied"
```

This allows proper error handling at the call site:

```csharp
catch (TaxonomyException ex) when (ex.ErrorCode == 105)
{
    // handle access denied
}
catch (TaxonomyException ex) when (ex.StatusCode == HttpStatusCode.UnprocessableEntity)
{
    // handle validation errors — inspect ex.Errors
}
```

---

## Minor — `TermQuery.Find<T>()` empty fallback

Changed `new List<T>()` to `Enumerable.Empty<T>()` for the zero-terms case. Avoids allocating an empty list on every call that returns no terms.

---

## Out of scope

`Taxonomy.cs` still contains dead code carried over from the initial implementation: `_ObjectAttributes`, `_Headers`, `_StackHeaders`, `UrlQueries`, and `GetHeader()` are all declared but never used in any active code path. `GetContentstackError()` itself is now used but was previously dead. Cleaning up the remaining dead fields belongs in a separate PR to keep the diff reviewable.

---

## Test results

```
Passed!  - Failed: 0, Passed: 46, Skipped: 0, Total: 46
Contentstack.Core.Unit.Tests — TaxonomyUnitTests (net7.0)
```

Integration tests (`TaxonomyLocalisationTest`) cover all eight CDA endpoints against the real API and pass unchanged.