### PR TITLE
DX | 03-08-2026 | Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### Version: 2.30.0
+#### Date: Aug-3-2026
+
+##### Feat:
+- Taxonomy — list all published taxonomies
+  - Added `Taxonomies().Find<T>()`, mapping to `GET /taxonomies`
+- Term / TermQuery — hierarchy depth and branch info
+  - Added `Depth(int)` and `IncludeBranch()` to `Term` and `TermQuery`, applying to `Ancestors<T>()`/`Descendants<T>()`/`Find<T>()`
+  - Added `Skip(int)`, `Limit(int)`, `IncludeCount()` to `TermQuery` for paginated term listing
+
+##### Fix:
+- Term — incorrect response envelope keys
+  - `Locales<T>()`, `Ancestors<T>()`, and `Descendants<T>()` were reading the response body under `$.locales`/`$.ancestors`/`$.descendants`, but the CDA actually wraps all three under `$.terms`. This silently returned the wrong (whole-envelope) object for loosely-typed callers and threw a deserialization exception for strictly-typed ones (e.g. `JArray`).
+- Taxonomy / Term / TermQuery — duplicated request/header/error logic
+  - Consolidated request-building, header-merging, and error-parsing (previously duplicated independently in `Taxonomy`, `Term`, and `TermQuery`) into a single `Internals/TaxonomyRequestHelper`. Also fixes a latent bug where `Taxonomy`'s local-header merge logic existed but was never actually invoked by any request path.
+
 ### Version: 2.29.0
 #### Date: Jul-16-2026
 

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Contentstack.Core.Configuration;
-using Contentstack.Core.Models;
-using Contentstack.Core.Internals;
 using Contentstack.Core.Tests.Helpers;
 
 namespace Contentstack.Core.Tests.Integration.Taxonomy
@@ -272,6 +270,233 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
                 .Term(termUid)
                 .Descendants<Newtonsoft.Json.Linq.JToken>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+        }
+
+        // ── 8. Term hierarchy — Depth / IncludeBranch ────────────────────────
+
+        /// <summary>
+        /// Walks the gadgets taxonomy to find a term with at least one descendant that itself
+        /// has a descendant — i.e. a parent/child/grandchild chain — for hierarchy-depth tests.
+        /// Returns (null, null, null) if no such chain exists in the fixture data.
+        /// </summary>
+        private async Task<(string parentUid, string childUid, string grandchildUid)> GetTermHierarchyAsync(ContentstackClient client)
+        {
+            var terms = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .Find<Newtonsoft.Json.Linq.JObject>();
+
+            foreach (var candidateParent in terms.Items)
+            {
+                var parentUid = candidateParent["uid"]?.ToString();
+                if (string.IsNullOrEmpty(parentUid)) continue;
+
+                var children = await client
+                    .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                    .Term(parentUid)
+                    .Descendants<Newtonsoft.Json.Linq.JArray>();
+                var childUid = children?.FirstOrDefault()?["uid"]?.ToString();
+                if (string.IsNullOrEmpty(childUid)) continue;
+
+                var grandchildren = await client
+                    .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                    .Term(childUid)
+                    .Descendants<Newtonsoft.Json.Linq.JArray>();
+                var grandchildUid = grandchildren?.FirstOrDefault()?["uid"]?.ToString();
+                if (string.IsNullOrEmpty(grandchildUid)) continue;
+
+                return (parentUid, childUid, grandchildUid);
+            }
+            return (null, null, null);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Descendants with depth=1 returns only direct children")]
+        public async Task Term_Descendants_WithDepth1_ReturnsOnlyDirectChildren()
+        {
+            var client = CreateGadgetsClient();
+            var (parentUid, childUid, grandchildUid) = await GetTermHierarchyAsync(client);
+
+            if (string.IsNullOrEmpty(parentUid))
+            {
+                Output.WriteLine("No parent/child/grandchild term chain found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching direct-child-only descendants (depth=1)");
+            LogContext("ParentTermUid", parentUid);
+
+            LogAct("Calling Term(parentUid).Depth(1).Descendants<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(parentUid)
+                .Depth(1)
+                .Descendants<Newtonsoft.Json.Linq.JArray>();
+
+            LogAssert("Verifying only the direct child is present, not the grandchild");
+            Assert.NotNull(result);
+            var uids = result.Select(t => t["uid"]?.ToString()).ToList();
+            Assert.Contains(childUid, uids);
+            Assert.DoesNotContain(grandchildUid, uids);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Descendants with depth=2 includes grandchildren")]
+        public async Task Term_Descendants_WithDepth2_IncludesGrandchildren()
+        {
+            var client = CreateGadgetsClient();
+            var (parentUid, childUid, grandchildUid) = await GetTermHierarchyAsync(client);
+
+            if (string.IsNullOrEmpty(parentUid))
+            {
+                Output.WriteLine("No parent/child/grandchild term chain found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching descendants two levels deep (depth=2)");
+            LogContext("ParentTermUid", parentUid);
+
+            LogAct("Calling Term(parentUid).Depth(2).Descendants<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(parentUid)
+                .Depth(2)
+                .Descendants<Newtonsoft.Json.Linq.JArray>();
+
+            LogAssert("Verifying both the child and grandchild are present");
+            Assert.NotNull(result);
+            var uids = result.Select(t => t["uid"]?.ToString()).ToList();
+            Assert.Contains(childUid, uids);
+            Assert.Contains(grandchildUid, uids);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Ancestors for a grandchild term returns the full parent chain")]
+        public async Task Term_Ancestors_ForGrandchildTerm_ReturnsFullChain()
+        {
+            var client = CreateGadgetsClient();
+            var (parentUid, childUid, grandchildUid) = await GetTermHierarchyAsync(client);
+
+            if (string.IsNullOrEmpty(grandchildUid))
+            {
+                Output.WriteLine("No parent/child/grandchild term chain found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching ancestors for the grandchild term");
+            LogContext("GrandchildTermUid", grandchildUid);
+
+            LogAct("Calling Term(grandchildUid).Ancestors<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(grandchildUid)
+                .Ancestors<Newtonsoft.Json.Linq.JArray>();
+
+            LogAssert("Verifying both the parent and child (grandparent chain) are present");
+            Assert.NotNull(result);
+            var uids = result.Select(t => t["uid"]?.ToString()).ToList();
+            Assert.Contains(childUid, uids);
+            Assert.Contains(parentUid, uids);
+        }
+
+        [Fact(DisplayName = "TaxPublish - TermQuery.Find with depth limits the returned hierarchy")]
+        public async Task TermQuery_Find_WithDepth_LimitsHierarchyDepth()
+        {
+            var client = CreateGadgetsClient();
+
+            LogArrange("Finding terms with depth=1");
+            LogContext("TaxonomyUid", TestDataHelper.TaxPublishTaxonomyUid);
+
+            LogAct("Calling Terms().Depth(1).Find<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Terms()
+                .Depth(1)
+                .Find<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result.Items);
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Fetch with IncludeBranch returns branch info")]
+        public async Task Term_Fetch_WithIncludeBranch_ReturnsBranchInfo()
+        {
+            var client = CreateGadgetsClient();
+            var termUid = await GetFirstTermUidAsync(client);
+
+            if (string.IsNullOrEmpty(termUid))
+            {
+                Output.WriteLine("No term UID found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching a term with branch info included");
+            LogContext("TermUid", termUid);
+
+            LogAct("Calling Term(termUid).IncludeBranch().Fetch<JObject>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(termUid)
+                .IncludeBranch()
+                .Fetch<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result["uid"]?.ToString());
+        }
+
+        // ── 9. List all taxonomies ────────────────────────────────────────────
+
+        [Fact(DisplayName = "TaxPublish - List all taxonomies returns a collection")]
+        public async Task List_AllTaxonomies_ReturnsCollection()
+        {
+            var client = CreateGadgetsClient();
+
+            LogArrange("Listing all published taxonomies");
+
+            LogAct("Calling Taxonomies().List<JObject>()");
+            var result = await client
+                .Taxonomies()
+                .List<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response");
+            Assert.NotNull(result);
+            Assert.NotNull(result.Items);
+            Assert.True(result.Items.Any());
+        }
+
+        [Fact(DisplayName = "TaxPublish - List all taxonomies with skip/limit returns a paged subset")]
+        public async Task List_AllTaxonomies_WithSkipAndLimit_ReturnsPagedSubset()
+        {
+            var client = CreateGadgetsClient();
+
+            LogArrange("Listing taxonomies with skip/limit");
+
+            LogAct("Calling Taxonomies().AddParam(\"skip\",\"0\").AddParam(\"limit\",\"1\").List<JObject>()");
+            var result = await client
+                .Taxonomies()
+                .AddParam("skip", "0")
+                .AddParam("limit", "1")
+                .List<Newtonsoft.Json.Linq.JObject>();
+
+            LogAssert("Verifying response is limited to at most one item");
+            Assert.NotNull(result);
+            Assert.True(result.Items.Count() <= 1);
+        }
+
+        [Fact(DisplayName = "TaxPublish - List all taxonomies with include_count returns a count")]
+        public async Task List_AllTaxonomies_WithIncludeCount_ReturnsCount()
+        {
+            var client = CreateGadgetsClient();
+
+            LogArrange("Listing taxonomies with include_count");
+
+            LogAct("Calling Taxonomies().AddParam(\"include_count\",\"true\").List<JObject>()");
+            var result = await client
+                .Taxonomies()
+                .AddParam("include_count", "true")
+                .List<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -455,10 +455,10 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
 
             LogArrange("Listing all published taxonomies");
 
-            LogAct("Calling Taxonomies().List<JObject>()");
+            LogAct("Calling Taxonomies().Find<JObject>()");
             var result = await client
                 .Taxonomies()
-                .List<Newtonsoft.Json.Linq.JObject>();
+                .Find<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);
@@ -473,12 +473,12 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
 
             LogArrange("Listing taxonomies with skip/limit");
 
-            LogAct("Calling Taxonomies().AddParam(\"skip\",\"0\").AddParam(\"limit\",\"1\").List<JObject>()");
+            LogAct("Calling Taxonomies().AddParam(\"skip\",\"0\").AddParam(\"limit\",\"1\").Find<JObject>()");
             var result = await client
                 .Taxonomies()
                 .AddParam("skip", "0")
                 .AddParam("limit", "1")
-                .List<Newtonsoft.Json.Linq.JObject>();
+                .Find<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response is limited to at most one item");
             Assert.NotNull(result);
@@ -492,11 +492,11 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
 
             LogArrange("Listing taxonomies with include_count");
 
-            LogAct("Calling Taxonomies().AddParam(\"include_count\",\"true\").List<JObject>()");
+            LogAct("Calling Taxonomies().AddParam(\"include_count\",\"true\").Find<JObject>()");
             var result = await client
                 .Taxonomies()
                 .AddParam("include_count", "true")
-                .List<Newtonsoft.Json.Linq.JObject>();
+                .Find<Newtonsoft.Json.Linq.JObject>();
 
             LogAssert("Verifying response");
             Assert.NotNull(result);

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomyLocalisationTest.cs
@@ -446,6 +446,87 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
             Assert.NotNull(result["uid"]?.ToString());
         }
 
+        [Fact(DisplayName = "TaxPublish - Term.Descendants with locale and fallback returns localized child+grandchild hierarchy")]
+        public async Task Term_Descendants_WithLocaleAndFallback_ReturnsLocalizedHierarchy()
+        {
+            var client = CreateGadgetsClient();
+            var (parentUid, childUid, grandchildUid) = await GetTermHierarchyAsync(client);
+
+            if (string.IsNullOrEmpty(parentUid))
+            {
+                Output.WriteLine("No parent/child/grandchild term chain found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching localized descendants (depth=2) with fallback, down to grandchild level");
+            LogContext("ParentTermUid", parentUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            LogAct("Calling Term(parentUid).SetLocale(locale).IncludeFallback().Depth(2).Descendants<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(parentUid)
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .IncludeFallback()
+                .Depth(2)
+                .Descendants<Newtonsoft.Json.Linq.JArray>();
+
+            LogAssert("Verifying both child and grandchild are present, each localized or correctly fallen back");
+            Assert.NotNull(result);
+            var uids = result.Select(t => t["uid"]?.ToString()).ToList();
+            Assert.Contains(childUid, uids);
+            Assert.Contains(grandchildUid, uids);
+
+            // Every returned term must be either in the requested locale (translated) or the
+            // master locale (fallen back) - never some third, unrelated locale.
+            foreach (var term in result)
+            {
+                var locale = term["locale"]?.ToString();
+                Assert.True(
+                    locale == TestDataHelper.TaxPublishLocale || locale == "en-us",
+                    $"Term '{term["uid"]}' returned unexpected locale '{locale}' - expected '{TestDataHelper.TaxPublishLocale}' (translated) or 'en-us' (fallback).");
+            }
+        }
+
+        [Fact(DisplayName = "TaxPublish - Term.Ancestors with locale and fallback returns localized ancestor chain")]
+        public async Task Term_Ancestors_WithLocaleAndFallback_ReturnsLocalizedChain()
+        {
+            var client = CreateGadgetsClient();
+            var (parentUid, childUid, grandchildUid) = await GetTermHierarchyAsync(client);
+
+            if (string.IsNullOrEmpty(grandchildUid))
+            {
+                Output.WriteLine("No parent/child/grandchild term chain found — skipping test.");
+                return;
+            }
+
+            LogArrange("Fetching localized ancestors for the grandchild term, with fallback");
+            LogContext("GrandchildTermUid", grandchildUid);
+            LogContext("Locale", TestDataHelper.TaxPublishLocale);
+
+            LogAct("Calling Term(grandchildUid).SetLocale(locale).IncludeFallback().Ancestors<JArray>()");
+            var result = await client
+                .Taxonomies(TestDataHelper.TaxPublishTaxonomyUid)
+                .Term(grandchildUid)
+                .SetLocale(TestDataHelper.TaxPublishLocale)
+                .IncludeFallback()
+                .Ancestors<Newtonsoft.Json.Linq.JArray>();
+
+            LogAssert("Verifying both parent and child (the ancestor chain) are present and correctly localized/fallen back");
+            Assert.NotNull(result);
+            var uids = result.Select(t => t["uid"]?.ToString()).ToList();
+            Assert.Contains(childUid, uids);
+            Assert.Contains(parentUid, uids);
+
+            foreach (var term in result)
+            {
+                var locale = term["locale"]?.ToString();
+                Assert.True(
+                    locale == TestDataHelper.TaxPublishLocale || locale == "en-us",
+                    $"Term '{term["uid"]}' returned unexpected locale '{locale}' - expected '{TestDataHelper.TaxPublishLocale}' (translated) or 'en-us' (fallback).");
+            }
+        }
+
         // ── 9. List all taxonomies ────────────────────────────────────────────
 
         [Fact(DisplayName = "TaxPublish - List all taxonomies returns a collection")]

--- a/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomySupportTest.cs
+++ b/Contentstack.Core.Tests/Integration/Taxonomy/TaxonomySupportTest.cs
@@ -371,17 +371,29 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
                 TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                // Taxonomy may not be configured - test passes if method exists
-                TestAssert.True(true, "Taxonomy.Exists() method executed");
+                // Taxonomy term not configured on this stack - acceptable, but must be this exception type with a real message
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -401,16 +413,21 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.Count();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                // Taxonomy may not be configured - test passes if method exists
-                TestAssert.True(true, "Taxonomy.Count() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -430,16 +447,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.FindOne<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                // Taxonomy may not be configured - test passes if method exists
-                TestAssert.True(true, "Taxonomy.FindOne() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -460,15 +489,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.Exists("taxonomies.one");
                 taxonomy.Skip(0);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.Skip() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -489,15 +531,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.Exists("taxonomies.one");
                 taxonomy.Limit(10);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.Limit() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -518,15 +573,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.Exists("taxonomies.one");
                 taxonomy.IncludeCount();
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.IncludeCount() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -547,15 +615,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.Exists("taxonomies.one");
                 taxonomy.IncludeMetadata();
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.IncludeMetadata() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -576,15 +657,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.Exists("taxonomies.one");
                 taxonomy.SetLocale("en-us");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.SetLocale() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -604,15 +698,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy object with environment executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -632,15 +739,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy object with branch executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -661,15 +781,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 taxonomy.SetHeader("custom_header", "value");
                 taxonomy.Exists("taxonomies.one");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.SetHeader() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -689,15 +822,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Above("taxonomies.one", 1);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.Above() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -717,15 +863,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Below("taxonomies.one", 5);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.Below() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -745,15 +904,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.EqualAndAbove("taxonomies.one", 2);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.EqualAndAbove() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -773,15 +945,28 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.EqualAndBelow("taxonomies.one", 3);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // Assert
             LogAssert("Verifying response");
 
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
+                foreach (var entry in result.Items)
+                {
+                    TestAssert.NotNull(entry.Uid);
+                    TestAssert.NotEmpty(entry.Uid);
+                }
             }
-            catch (Exception)
+            catch (TaxonomyException ex)
             {
-                TestAssert.True(true, "Taxonomy.EqualAndBelow() method executed");
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
+            }
+            catch (ContentstackException ex)
+            {
+                TestAssert.NotNull(ex.Message);
+                TestAssert.NotEmpty(ex.Message);
             }
         }
         
@@ -806,9 +991,11 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 // Use invalid taxonomy that might return non-JSON error or null response
                 taxonomy.Above("invalid.taxonomy.path.xyz.123", 1);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 // If no exception, test passes
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
             }
             catch (TaxonomyException ex)
             {
@@ -851,8 +1038,10 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.Exists("non.existent.taxonomy.xyz");
                 var result = await taxonomy.Find<Entry>();
-                
+
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
             }
             catch (TaxonomyException ex)
             {
@@ -885,8 +1074,10 @@ namespace Contentstack.Core.Tests.Integration.Taxonomy
                 TaxonomyModel taxonomy = client.Taxonomies();
                 taxonomy.EqualAndBelow("invalid_taxonomy_xyz_123", 0);
                 var result = await taxonomy.Find<Entry>();
-                
+
                 TestAssert.NotNull(result);
+                TestAssert.NotNull(result.Items);
+                TestAssert.IsAssignableFrom<IEnumerable<Entry>>(result.Items);
             }
             catch (TaxonomyException ex)
             {

--- a/Contentstack.Core.Unit.Tests/Contentstack.Core.Unit.Tests.csproj
+++ b/Contentstack.Core.Unit.Tests/Contentstack.Core.Unit.Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Remove="**/*.resx" />
     <EmbeddedResource Include="Mokes\Response\*.txt" />
   </ItemGroup>
 

--- a/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
@@ -895,6 +895,72 @@ namespace Contentstack.Core.Unit.Tests
 
         #endregion
 
+        #region Taxonomy.Find Routing (HasEntryFilters) Tests
+
+        [Fact]
+        public void HasEntryFilters_FalseByDefault_OnFreshTaxonomy()
+        {
+            var taxonomy = CreateTaxonomy();
+            Assert.False(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_TrueAfterAbove()
+        {
+            var taxonomy = CreateTaxonomy();
+            taxonomy.Above(_fixture.Create<string>(), 1);
+            Assert.True(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_TrueAfterBelow()
+        {
+            var taxonomy = CreateTaxonomy();
+            taxonomy.Below(_fixture.Create<string>(), 1);
+            Assert.True(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_TrueAfterEqualAndAbove()
+        {
+            var taxonomy = CreateTaxonomy();
+            taxonomy.EqualAndAbove(_fixture.Create<string>(), 1);
+            Assert.True(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_TrueAfterEqualAndBelow()
+        {
+            var taxonomy = CreateTaxonomy();
+            taxonomy.EqualAndBelow(_fixture.Create<string>(), 1);
+            Assert.True(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_TrueAfterExists_InheritedFromQuery()
+        {
+            var taxonomy = CreateTaxonomy();
+            taxonomy.Exists(_fixture.Create<string>());
+            Assert.True(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public void HasEntryFilters_FalseAfterAddParam_ListAllPathStillUsed()
+        {
+            var taxonomy = _client.Taxonomies().AddParam("skip", "0");
+            Assert.False(taxonomy.HasEntryFilters);
+        }
+
+        [Fact]
+        public async Task Taxonomy_Find_OnScopedInstance_ThrowsTaxonomyException_EvenWithFilters()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            taxonomy.Above("category", "electronics");
+            await Assert.ThrowsAsync<TaxonomyException>(() => taxonomy.Find<Newtonsoft.Json.Linq.JObject>());
+        }
+
+        #endregion
+
         #region Term.SetLocale / IncludeFallback / AddParam Tests
 
         [Fact]

--- a/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
@@ -867,17 +867,17 @@ namespace Contentstack.Core.Unit.Tests
 
         #endregion
 
-        #region Taxonomy.List Tests
+        #region Taxonomy.Find Tests
 
         [Fact]
-        public async Task Taxonomy_List_OnScopedInstance_ThrowsTaxonomyException()
+        public async Task Taxonomy_Find_OnScopedInstance_ThrowsTaxonomyException()
         {
             var taxonomy = _client.Taxonomies("gadgets");
-            await Assert.ThrowsAsync<TaxonomyException>(() => taxonomy.List<Newtonsoft.Json.Linq.JObject>());
+            await Assert.ThrowsAsync<TaxonomyException>(() => taxonomy.Find<Newtonsoft.Json.Linq.JObject>());
         }
 
         [Fact]
-        public void Taxonomy_List_AddParam_SetsSkipLimitIncludeCountParams()
+        public void Taxonomy_Find_AddParam_SetsSkipLimitIncludeCountParams()
         {
             var taxonomy = _client.Taxonomies()
                 .AddParam("skip", "0")

--- a/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
+++ b/Contentstack.Core.Unit.Tests/TaxonomyUnitTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using AutoFixture;
 using Contentstack.Core;
 using Contentstack.Core.Configuration;
@@ -284,62 +285,55 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithLocalHeaders_ReturnsMergedHeaders()
+        public void TaxonomyRequestHelper_GetHeader_WithLocalHeaders_ReturnsMergedHeaders()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var type = typeof(Taxonomy);
-            var getHeaderMethod = type.GetMethod("GetHeader", BindingFlags.NonPublic | BindingFlags.Instance);
-            
+            var stackHeaders = new Dictionary<string, object> { { "stack-header", "stack-value" } };
             var localHeaders = new Dictionary<string, object> { { "custom-header", "value1" } };
-            
+
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { localHeaders }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(stackHeaders, localHeaders);
 
             // Assert
             Assert.NotNull(result);
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithNullLocalHeaders_ReturnsStackHeaders()
+        public void TaxonomyRequestHelper_GetHeader_WithNullLocalHeaders_ReturnsStackHeaders()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var type = typeof(Taxonomy);
-            var getHeaderMethod = type.GetMethod("GetHeader", BindingFlags.NonPublic | BindingFlags.Instance);
-            
+            var stackHeaders = new Dictionary<string, object> { { "stack-header", "stack-value" } };
+
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { null }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(stackHeaders, null);
 
             // Assert
             Assert.NotNull(result);
+            Assert.Same(stackHeaders, result);
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithEmptyLocalHeaders_ReturnsStackHeaders()
+        public void TaxonomyRequestHelper_GetHeader_WithEmptyLocalHeaders_ReturnsStackHeaders()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var type = typeof(Taxonomy);
-            var getHeaderMethod = type.GetMethod("GetHeader", BindingFlags.NonPublic | BindingFlags.Instance);
-            
+            var stackHeaders = new Dictionary<string, object> { { "stack-header", "stack-value" } };
+
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { new Dictionary<string, object>() }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(stackHeaders, new Dictionary<string, object>());
 
             // Assert
             Assert.NotNull(result);
+            Assert.Same(stackHeaders, result);
         }
 
         [Fact]
-        public void Taxonomy_GetContentstackError_WithWebException_ReturnsContentstackException()
+        public void TaxonomyRequestHelper_GetContentstackError_WithWebException_ReturnsContentstackException()
         {
             // Arrange
-            var type = typeof(Taxonomy);
-            var getContentstackErrorMethod = type.GetMethod("GetContentstackError", BindingFlags.NonPublic | BindingFlags.Static);
             var webEx = new System.Net.WebException("Test exception");
 
             // Act
-            var result = getContentstackErrorMethod?.Invoke(null, new object[] { webEx }) as ContentstackException;
+            var result = TaxonomyRequestHelper.GetContentstackError(webEx);
 
             // Assert
             Assert.NotNull(result);
@@ -347,15 +341,13 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void Taxonomy_GetContentstackError_WithGenericException_ReturnsContentstackException()
+        public void TaxonomyRequestHelper_GetContentstackError_WithGenericException_ReturnsContentstackException()
         {
             // Arrange
-            var type = typeof(Taxonomy);
-            var getContentstackErrorMethod = type.GetMethod("GetContentstackError", BindingFlags.NonPublic | BindingFlags.Static);
             var ex = new Exception("Test exception");
 
             // Act
-            var result = getContentstackErrorMethod?.Invoke(null, new object[] { ex }) as ContentstackException;
+            var result = TaxonomyRequestHelper.GetContentstackError(ex);
 
             // Assert
             Assert.NotNull(result);
@@ -397,21 +389,13 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithLocalHeaderAndEmptyStackHeaders_ReturnsLocalHeader()
+        public void TaxonomyRequestHelper_GetHeader_WithLocalHeaderAndEmptyStackHeaders_ReturnsLocalHeader()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var getHeaderMethod = typeof(Taxonomy).GetMethod("GetHeader", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
             var localHeader = new Dictionary<string, object> { { "custom", "value" } };
-            
-            // Set _StackHeaders to empty dictionary
-            var stackHeadersField = typeof(Taxonomy).GetField("_StackHeaders", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            stackHeadersField?.SetValue(taxonomy, new Dictionary<string, object>());
 
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { localHeader }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(new Dictionary<string, object>(), localHeader);
 
             // Assert
             Assert.NotNull(result);
@@ -419,16 +403,14 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithOverlappingKeys_LocalHeaderTakesPrecedence()
+        public void TaxonomyRequestHelper_GetHeader_WithOverlappingKeys_LocalHeaderTakesPrecedence()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var getHeaderMethod = typeof(Taxonomy).GetMethod("GetHeader", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
+            var stackHeaders = new Dictionary<string, object> { { "custom", "stack_value" } };
             var localHeader = new Dictionary<string, object> { { "custom", "local_value" } };
 
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { localHeader }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(stackHeaders, localHeader);
 
             // Assert
             Assert.NotNull(result);
@@ -436,32 +418,29 @@ namespace Contentstack.Core.Unit.Tests
         }
 
         [Fact]
-        public void Taxonomy_GetHeader_WithBothHeaders_ReturnsMergedHeaders()
+        public void TaxonomyRequestHelper_GetHeader_WithBothHeaders_ReturnsMergedHeaders()
         {
             // Arrange
-            var taxonomy = CreateTaxonomy();
-            var getHeaderMethod = typeof(Taxonomy).GetMethod("GetHeader", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
+            var stackHeaders = new Dictionary<string, object> { { "stack_key", "stack_value" } };
             var localHeader = new Dictionary<string, object> { { "local_key", "local_value" } };
 
             // Act
-            var result = getHeaderMethod?.Invoke(taxonomy, new object[] { localHeader }) as Dictionary<string, object>;
+            var result = TaxonomyRequestHelper.GetHeader(stackHeaders, localHeader);
 
             // Assert
             Assert.NotNull(result);
             Assert.True(result.ContainsKey("local_key"));
+            Assert.True(result.ContainsKey("stack_key"));
         }
 
         [Fact]
-        public void Taxonomy_GetContentstackError_WithWebExceptionContainingErrorCode_ExtractsErrorCode()
+        public void TaxonomyRequestHelper_GetContentstackError_WithWebExceptionContainingErrorCode_ExtractsErrorCode()
         {
             // Arrange
-            var type = typeof(Taxonomy);
-            var getContentstackErrorMethod = type.GetMethod("GetContentstackError", BindingFlags.NonPublic | BindingFlags.Static);
             var webEx = new System.Net.WebException("Test exception");
 
             // Act
-            var result = getContentstackErrorMethod?.Invoke(null, new object[] { webEx }) as ContentstackException;
+            var result = TaxonomyRequestHelper.GetContentstackError(webEx);
 
             // Assert
             Assert.NotNull(result);
@@ -717,6 +696,87 @@ namespace Contentstack.Core.Unit.Tests
 
         #endregion
 
+        #region TermQuery.Skip / Limit / IncludeCount Tests
+
+        [Fact]
+        public void TermQuery_IncludeBranch_SetsQueryParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.IncludeBranch();
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("include_branch") ?? false);
+            Assert.Equal("true", queryParams["include_branch"]);
+        }
+
+        [Fact]
+        public void TermQuery_Skip_SetsQueryParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.Skip(10);
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("skip") ?? false);
+            Assert.Equal(10, queryParams["skip"]);
+        }
+
+        [Fact]
+        public void TermQuery_Limit_SetsQueryParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.Limit(10);
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("limit") ?? false);
+            Assert.Equal(10, queryParams["limit"]);
+        }
+
+        [Fact]
+        public void TermQuery_IncludeCount_SetsQueryParam()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms();
+            termQuery.IncludeCount();
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("include_count") ?? false);
+            Assert.Equal("true", queryParams["include_count"]);
+        }
+
+        [Fact]
+        public void TermQuery_Skip_Limit_IncludeCount_Depth_ChainAllTogether()
+        {
+            var termQuery = _client.Taxonomies("gadgets").Terms()
+                .Skip(0)
+                .Limit(10)
+                .IncludeCount()
+                .Depth(2)
+                .IncludeBranch();
+
+            var field = typeof(TermQuery).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(termQuery);
+
+            Assert.True(queryParams?.ContainsKey("skip") ?? false);
+            Assert.True(queryParams?.ContainsKey("limit") ?? false);
+            Assert.True(queryParams?.ContainsKey("include_count") ?? false);
+            Assert.True(queryParams?.ContainsKey("depth") ?? false);
+            Assert.True(queryParams?.ContainsKey("include_branch") ?? false);
+        }
+
+        #endregion
+
         #region Taxonomy.SetLocale / IncludeFallback / AddParam Tests
 
         [Fact]
@@ -807,6 +867,34 @@ namespace Contentstack.Core.Unit.Tests
 
         #endregion
 
+        #region Taxonomy.List Tests
+
+        [Fact]
+        public async Task Taxonomy_List_OnScopedInstance_ThrowsTaxonomyException()
+        {
+            var taxonomy = _client.Taxonomies("gadgets");
+            await Assert.ThrowsAsync<TaxonomyException>(() => taxonomy.List<Newtonsoft.Json.Linq.JObject>());
+        }
+
+        [Fact]
+        public void Taxonomy_List_AddParam_SetsSkipLimitIncludeCountParams()
+        {
+            var taxonomy = _client.Taxonomies()
+                .AddParam("skip", "0")
+                .AddParam("limit", "10")
+                .AddParam("include_count", "true");
+
+            var field = typeof(Taxonomy).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var urlQueries = (Dictionary<string, object>)field?.GetValue(taxonomy);
+
+            Assert.True(urlQueries?.ContainsKey("skip") ?? false);
+            Assert.True(urlQueries?.ContainsKey("limit") ?? false);
+            Assert.True(urlQueries?.ContainsKey("include_count") ?? false);
+        }
+
+        #endregion
+
         #region Term.SetLocale / IncludeFallback / AddParam Tests
 
         [Fact]
@@ -893,6 +981,69 @@ namespace Contentstack.Core.Unit.Tests
 
             Assert.True(queryParams?.ContainsKey("locale") ?? false);
             Assert.True(queryParams?.ContainsKey("include_fallback") ?? false);
+        }
+
+        #endregion
+
+        #region Term.Depth / IncludeBranch Tests
+
+        [Fact]
+        public void Term_Depth_ReturnsSelfForChaining()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            var result = term.Depth(2);
+            Assert.Same(term, result);
+        }
+
+        [Fact]
+        public void Term_Depth_SetsQueryParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.Depth(2);
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("depth") ?? false);
+            Assert.Equal(2, queryParams["depth"]);
+        }
+
+        [Fact]
+        public void Term_IncludeBranch_ReturnsSelfForChaining()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            var result = term.IncludeBranch();
+            Assert.Same(term, result);
+        }
+
+        [Fact]
+        public void Term_IncludeBranch_SetsQueryParam()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch");
+            term.IncludeBranch();
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("include_branch") ?? false);
+            Assert.Equal("true", queryParams["include_branch"]);
+        }
+
+        [Fact]
+        public void Term_Depth_Then_IncludeBranch_ChainsBoth()
+        {
+            var term = _client.Taxonomies("gadgets").Term("smartwatch")
+                .Depth(2)
+                .IncludeBranch();
+
+            var field = typeof(Term).GetField("UrlQueries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var queryParams = (Dictionary<string, object>)field?.GetValue(term);
+
+            Assert.True(queryParams?.ContainsKey("depth") ?? false);
+            Assert.True(queryParams?.ContainsKey("include_branch") ?? false);
         }
 
         #endregion

--- a/Contentstack.Core/Internals/TaxonomyRequestHelper.cs
+++ b/Contentstack.Core/Internals/TaxonomyRequestHelper.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Contentstack.Core.Internals
+{
+    /// <summary>
+    /// Shared request-building, header-merging, and error-handling logic for the CDA
+    /// Taxonomy/Term/TermQuery classes. Every taxonomy-related HTTP call goes through
+    /// <see cref="ExecuteRequest"/> so header merging and error parsing behave identically
+    /// across <c>Taxonomy</c>, <c>Term</c>, and <c>TermQuery</c>.
+    /// </summary>
+    internal static class TaxonomyRequestHelper
+    {
+        /// <summary>
+        /// Merges a call-local header set with the stack's headers, local values taking precedence.
+        /// Passing null or empty for <paramref name="localHeader"/> returns the stack headers unchanged.
+        /// </summary>
+        internal static Dictionary<string, object> GetHeader(Dictionary<string, object> stackHeaders, Dictionary<string, object> localHeader)
+        {
+            if (localHeader != null && localHeader.Count > 0)
+            {
+                if (stackHeaders != null && stackHeaders.Count > 0)
+                {
+                    Dictionary<string, object> classHeaders = new Dictionary<string, object>();
+                    foreach (var entry in localHeader)
+                        classHeaders.Add(entry.Key, entry.Value);
+
+                    foreach (var entry in stackHeaders)
+                        if (!classHeaders.ContainsKey(entry.Key))
+                            classHeaders.Add(entry.Key, entry.Value);
+
+                    return classHeaders;
+                }
+                return localHeader;
+            }
+            return stackHeaders;
+        }
+
+        /// <summary>
+        /// Builds and sends a taxonomy/term GET request against the CDA and returns the raw response body.
+        /// </summary>
+        /// <param name="stack">The owning client, providing config, headers, and the HTTP handler.</param>
+        /// <param name="url">The fully-qualified request URL.</param>
+        /// <param name="urlQueries">Query parameters accumulated by the calling class's modifiers (locale, depth, skip, ...).</param>
+        /// <param name="localHeader">Optional call-local headers, merged with precedence over the stack's headers.</param>
+        internal static async Task<string> ExecuteRequest(
+            ContentstackClient stack,
+            string url,
+            Dictionary<string, object> urlQueries,
+            Dictionary<string, object> localHeader = null)
+        {
+            var headerAll = GetHeader(stack._LocalHeaders, localHeader);
+
+            var mainJson = new Dictionary<string, object>();
+            if (stack.Config?.Environment != null)
+                mainJson["environment"] = stack.Config.Environment;
+
+            if (urlQueries != null)
+                foreach (var kvp in urlQueries)
+                    mainJson[kvp.Key] = kvp.Value;
+
+            var handler = new HttpRequestHandler(stack);
+            return await handler.ProcessRequest(
+                url, headerAll, mainJson,
+                Branch: stack.Config.Branch,
+                timeout: stack.Config.Timeout,
+                proxy: stack.Config.Proxy
+            );
+        }
+
+        /// <summary>
+        /// Parses a failed taxonomy/term request into a <see cref="ContentstackException"/>,
+        /// extracting <c>error_code</c>/<c>error_message</c>/<c>errors</c> from the response body when present.
+        /// </summary>
+        internal static ContentstackException GetContentstackError(Exception ex)
+        {
+            Int32 errorCode = 0;
+            string errorMessage;
+            HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
+            Dictionary<string, object> errors = null;
+
+            try
+            {
+                System.Net.WebException webEx = ex as System.Net.WebException;
+
+                if (webEx != null && webEx.Response != null)
+                {
+                    using (var exResp = webEx.Response)
+                    {
+                        var stream = exResp.GetResponseStream();
+                        if (stream != null)
+                        {
+                            using (stream)
+                            using (var reader = new StreamReader(stream))
+                            {
+                                errorMessage = reader.ReadToEnd();
+
+                                if (!string.IsNullOrWhiteSpace(errorMessage))
+                                {
+                                    try
+                                    {
+                                        JObject data = JObject.Parse(errorMessage.Replace("\r\n", ""));
+
+                                        JToken token = data["error_code"];
+                                        if (token != null)
+                                            errorCode = token.Value<int>();
+
+                                        token = data["error_message"];
+                                        if (token != null)
+                                            errorMessage = token.Value<string>();
+
+                                        token = data["errors"];
+                                        if (token != null)
+                                            errors = token.ToObject<Dictionary<string, object>>();
+                                    }
+                                    catch (Newtonsoft.Json.JsonException)
+                                    {
+                                        // If JSON parsing fails, use the raw error message
+                                        // errorMessage is already set from ReadToEnd()
+                                    }
+                                }
+
+                                var response = exResp as HttpWebResponse;
+                                if (response != null)
+                                    statusCode = response.StatusCode;
+                            }
+                        }
+                        else
+                        {
+                            errorMessage = webEx.Message;
+                        }
+                    }
+                }
+                else
+                {
+                    errorMessage = ex.Message;
+                }
+            }
+            catch
+            {
+                errorMessage = ex.Message;
+            }
+
+            return new ContentstackException(errorMessage)
+            {
+                ErrorCode = errorCode,
+                StatusCode = statusCode,
+                Errors = errors
+            };
+        }
+    }
+}

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -197,24 +197,40 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
-        /// Fetches all published taxonomies from the CDA.
-        /// Only valid on an unscoped <see cref="Taxonomy"/> instance (<c>client.Taxonomies()</c>, no UID) —
-        /// throws <see cref="TaxonomyException"/> if called on a UID-scoped instance.
+        /// True once <see cref="Above"/>, <see cref="Below"/>, <see cref="EqualAndAbove"/>, <see cref="EqualAndBelow"/>,
+        /// or an inherited <c>Query</c> filter such as <c>Exists</c>/<c>NotExists</c> has added a constraint.
+        /// Used by <see cref="Find{T}"/> to decide whether to list taxonomies or filter entries by taxonomy term.
+        /// </summary>
+        internal bool HasEntryFilters => QueryValueJson != null && QueryValueJson.Count > 0;
+
+        /// <summary>
+        /// Fetches all published taxonomies from the CDA, or — if <see cref="Above"/>/<see cref="Below"/>/
+        /// <see cref="EqualAndAbove"/>/<see cref="EqualAndBelow"/>/<c>Exists</c>/<c>NotExists</c> was called first —
+        /// filters entries by their taxonomy term assignment (<c>GET /taxonomies/entries</c>) via the inherited
+        /// <see cref="Query.Find{T}"/> pipeline.
+        /// The list-all mode is only valid on an unscoped <see cref="Taxonomy"/> instance (<c>client.Taxonomies()</c>,
+        /// no UID) — throws <see cref="TaxonomyException"/> if called on a UID-scoped instance.
         /// Use <see cref="Query.Skip(int)"/>-style pagination via <see cref="AddParam"/>, or the
         /// dedicated <c>skip</c>/<c>limit</c>/<c>include_count</c> params, before calling.
         /// </summary>
-        /// <returns>A <see cref="ContentstackCollection{T}"/> containing the published taxonomies.</returns>
+        /// <returns>A <see cref="ContentstackCollection{T}"/> containing the published taxonomies or matching entries.</returns>
         /// <example>
         /// <code>
         ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
         ///     var result = await stack.Taxonomies().Find&lt;MyTaxonomy&gt;();
         ///     var page = await stack.Taxonomies().AddParam("skip", "0").AddParam("limit", "10").Find&lt;MyTaxonomy&gt;();
+        ///     var entries = await stack.Taxonomies().Above("category", "electronics").Find&lt;Entry&gt;();
         /// </code>
         /// </example>
         public new async Task<ContentstackCollection<T>> Find<T>()
         {
             if (_uid != null)
                 throw new TaxonomyException("Find() requires an unscoped Taxonomy. Use client.Taxonomies() without a UID.");
+
+            if (HasEntryFilters)
+            {
+                return await base.Find<T>();
+            }
 
             try
             {

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
+using System.Linq;
 using System.Threading.Tasks;
 using Contentstack.Core.Configuration;
 using Contentstack.Core.Internals;
-using Newtonsoft.Json.Linq;
 
 namespace Contentstack.Core.Models
 {
@@ -19,9 +17,6 @@ namespace Contentstack.Core.Models
     {
 
         #region Internal Variables
-        private Dictionary<string, object> _ObjectAttributes = new Dictionary<string, object>();
-        private Dictionary<string, object> _Headers = new Dictionary<string, object>();
-        private Dictionary<string, object> _StackHeaders = new Dictionary<string, object>();
         private Dictionary<string, object> UrlQueries = new Dictionary<string, object>();
         private string _uid = null;
 
@@ -62,7 +57,6 @@ namespace Contentstack.Core.Models
                 throw new TaxonomyException("ContentstackClient instance cannot be null when creating a Taxonomy instance.");
             }
             this.Stack = stack;
-            this._StackHeaders = stack._LocalHeaders;
         }
 
         internal Taxonomy(ContentstackClient stack, string uid) : this(stack)
@@ -182,23 +176,7 @@ namespace Contentstack.Core.Models
 
             try
             {
-                var headerAll = new Dictionary<string, object>();
-                foreach (var header in Stack._LocalHeaders)
-                    headerAll[header.Key] = header.Value;
-
-                var mainJson = new Dictionary<string, object>();
-                if (Stack.Config?.Environment != null)
-                    mainJson["environment"] = Stack.Config.Environment;
-                foreach (var kvp in UrlQueries)
-                    mainJson[kvp.Key] = kvp.Value;
-
-                var handler = new HttpRequestHandler(Stack);
-                var result = await handler.ProcessRequest(
-                    _Url, headerAll, mainJson,
-                    Branch: Stack.Config.Branch,
-                    timeout: Stack.Config.Timeout,
-                    proxy: Stack.Config.Proxy
-                );
+                var result = await TaxonomyRequestHelper.ExecuteRequest(Stack, _Url, UrlQueries);
 
                 var jObject = Newtonsoft.Json.Linq.JObject.Parse(result);
                 var token = jObject.SelectToken("$.taxonomy");
@@ -208,7 +186,51 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
+                throw new TaxonomyException(contentstackError.Message, ex)
+                {
+                    ErrorCode = contentstackError.ErrorCode,
+                    StatusCode = contentstackError.StatusCode,
+                    Errors = contentstackError.Errors
+                };
+            }
+        }
+
+        /// <summary>
+        /// Fetches all published taxonomies from the CDA.
+        /// Only valid on an unscoped <see cref="Taxonomy"/> instance (<c>client.Taxonomies()</c>, no UID) —
+        /// throws <see cref="TaxonomyException"/> if called on a UID-scoped instance.
+        /// Use <see cref="Query.Skip(int)"/>-style pagination via <see cref="AddParam"/>, or the
+        /// dedicated <c>skip</c>/<c>limit</c>/<c>include_count</c> params, before calling.
+        /// </summary>
+        /// <returns>A <see cref="ContentstackCollection{T}"/> containing the published taxonomies.</returns>
+        /// <example>
+        /// <code>
+        ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
+        ///     var result = await stack.Taxonomies().List&lt;MyTaxonomy&gt;();
+        ///     var page = await stack.Taxonomies().AddParam("skip", "0").AddParam("limit", "10").List&lt;MyTaxonomy&gt;();
+        /// </code>
+        /// </example>
+        public async Task<ContentstackCollection<T>> List<T>()
+        {
+            if (_uid != null)
+                throw new TaxonomyException("List() is only valid on an unscoped Taxonomy. Use client.Taxonomies() without a UID.");
+
+            try
+            {
+                Config config = this.Stack.Config;
+                var url = String.Format("{0}/taxonomies", config.BaseUrl);
+                var result = await TaxonomyRequestHelper.ExecuteRequest(Stack, url, UrlQueries);
+
+                var jObject = Newtonsoft.Json.Linq.JObject.Parse(result);
+                var taxonomies = jObject.SelectToken("$.taxonomies")?.ToObject<IEnumerable<T>>(Stack.Serializer);
+                var collection = jObject.ToObject<ContentstackCollection<T>>(Stack.Serializer);
+                collection.Items = taxonomies ?? Enumerable.Empty<T>();
+                return collection;
+            }
+            catch (Exception ex)
+            {
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,
@@ -372,126 +394,6 @@ namespace Contentstack.Core.Models
             return this;
         }
 
-        #endregion
-        #region Private Functions
-
-        private Dictionary<string, object> GetHeader(Dictionary<string, object> localHeader)
-        {
-            Dictionary<string, object> mainHeader = _StackHeaders;
-            Dictionary<string, object> classHeaders = new Dictionary<string, object>();
-
-            if (localHeader != null && localHeader.Count > 0)
-            {
-                if (mainHeader != null && mainHeader.Count > 0)
-                {
-                    foreach (var entry in localHeader)
-                    {
-                        String key = entry.Key;
-                        classHeaders.Add(key, entry.Value);
-                    }
-
-                    foreach (var entry in mainHeader)
-                    {
-                        String key = entry.Key;
-                        if (!classHeaders.ContainsKey(key))
-                        {
-                            classHeaders.Add(key, entry.Value);
-                        }
-                    }
-
-                    return classHeaders;
-
-                }
-                else
-                {
-                    return localHeader;
-                }
-
-            }
-            else
-            {
-                return _StackHeaders;
-            }
-        }
-        internal new static ContentstackException GetContentstackError(Exception ex)
-        {
-            Int32 errorCode = 0;
-            string errorMessage = string.Empty;
-            HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
-            ContentstackException contentstackError = new ContentstackException(ex);
-            Dictionary<string, object> errors = null;
-
-            try
-            {
-                System.Net.WebException webEx = ex as System.Net.WebException;
-                
-                if (webEx != null && webEx.Response != null)
-                {
-                    using (var exResp = webEx.Response)
-                    {
-                        var stream = exResp.GetResponseStream();
-                        if (stream != null)
-                        {
-                            using (stream)
-                            using (var reader = new StreamReader(stream))
-                            {
-                                errorMessage = reader.ReadToEnd();
-                                
-                                if (!string.IsNullOrWhiteSpace(errorMessage))
-                                {
-                                    try
-                                    {
-                                        JObject data = JObject.Parse(errorMessage.Replace("\r\n", ""));
-
-                                        JToken token = data["error_code"];
-                                        if (token != null)
-                                            errorCode = token.Value<int>();
-
-                                        token = data["error_message"];
-                                        if (token != null)
-                                            errorMessage = token.Value<string>();
-
-                                        token = data["errors"];
-                                        if (token != null)
-                                            errors = token.ToObject<Dictionary<string, object>>();
-                                    }
-                                    catch (Newtonsoft.Json.JsonException)
-                                    {
-                                        // If JSON parsing fails, use the raw error message
-                                        // errorMessage is already set from ReadToEnd()
-                                    }
-                                }
-
-                                var response = exResp as HttpWebResponse;
-                                if (response != null)
-                                    statusCode = response.StatusCode;
-                            }
-                        }
-                        else
-                        {
-                            errorMessage = webEx.Message;
-                        }
-                    }
-                }
-                else
-                {
-                    errorMessage = ex.Message;
-                }
-            }
-            catch
-            {
-                errorMessage = ex.Message;
-            }
-
-            contentstackError = new ContentstackException(errorMessage)
-            {
-                ErrorCode = errorCode,
-                StatusCode = statusCode,
-                Errors = errors
-            };
-
-            return contentstackError;
-        }
         #endregion
     }
 }

--- a/Contentstack.Core/Models/Taxonomy.cs
+++ b/Contentstack.Core/Models/Taxonomy.cs
@@ -207,14 +207,14 @@ namespace Contentstack.Core.Models
         /// <example>
         /// <code>
         ///     ContentstackClient stack = new ContentstackClient("api_key", "delivery_token", "environment");
-        ///     var result = await stack.Taxonomies().List&lt;MyTaxonomy&gt;();
-        ///     var page = await stack.Taxonomies().AddParam("skip", "0").AddParam("limit", "10").List&lt;MyTaxonomy&gt;();
+        ///     var result = await stack.Taxonomies().Find&lt;MyTaxonomy&gt;();
+        ///     var page = await stack.Taxonomies().AddParam("skip", "0").AddParam("limit", "10").Find&lt;MyTaxonomy&gt;();
         /// </code>
         /// </example>
-        public async Task<ContentstackCollection<T>> List<T>()
+        public new async Task<ContentstackCollection<T>> Find<T>()
         {
             if (_uid != null)
-                throw new TaxonomyException("List() is only valid on an unscoped Taxonomy. Use client.Taxonomies() without a UID.");
+                throw new TaxonomyException("Find() requires an unscoped Taxonomy. Use client.Taxonomies() without a UID.");
 
             try
             {

--- a/Contentstack.Core/Models/Term.cs
+++ b/Contentstack.Core/Models/Term.cs
@@ -83,6 +83,38 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
+        /// Limits the depth of the term hierarchy returned by <see cref="Ancestors{T}"/>/<see cref="Descendants{T}"/>.
+        /// <c>Depth(1)</c> returns only immediate parents/children; higher values include deeper levels.
+        /// </summary>
+        /// <param name="depth">The maximum number of hierarchy levels to include.</param>
+        /// <returns>The current <see cref="Term"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var children = await stack.Taxonomies("gadgets").Term("laptops").Depth(1).Descendants&lt;JToken&gt;();
+        /// </code>
+        /// </example>
+        public Term Depth(int depth)
+        {
+            UrlQueries["depth"] = depth;
+            return this;
+        }
+
+        /// <summary>
+        /// Includes branch information in the response for this term.
+        /// </summary>
+        /// <returns>The current <see cref="Term"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var term = await stack.Taxonomies("gadgets").Term("smartwatch").IncludeBranch().Fetch&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public Term IncludeBranch()
+        {
+            UrlQueries["include_branch"] = "true";
+            return this;
+        }
+
+        /// <summary>
         /// Fetches the published term from the CDA.
         /// Maps to GET /v3/taxonomies/{uid}/terms/{termUid} with any configured query parameters.
         /// </summary>
@@ -98,7 +130,7 @@ namespace Contentstack.Core.Models
         {
             try
             {
-                var result = await ExecuteRequest(BaseUrlPath, UrlQueries);
+                var result = await TaxonomyRequestHelper.ExecuteRequest(_stack, BaseUrlPath, UrlQueries);
                 var jObject = JObject.Parse(result);
                 var token = jObject.SelectToken("$.term");
                 if (token != null)
@@ -111,7 +143,7 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = Taxonomy.GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,
@@ -135,9 +167,9 @@ namespace Contentstack.Core.Models
         {
             try
             {
-                var result = await ExecuteRequest($"{BaseUrlPath}/locales");
+                var result = await TaxonomyRequestHelper.ExecuteRequest(_stack, $"{BaseUrlPath}/locales", null);
                 var jObject = JObject.Parse(result);
-                var token = jObject.SelectToken("$.locales");
+                var token = jObject.SelectToken("$.terms");
                 if (token != null)
                     return token.ToObject<T>(_stack.Serializer);
                 return jObject.ToObject<T>(_stack.Serializer);
@@ -148,7 +180,7 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = Taxonomy.GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,
@@ -172,9 +204,9 @@ namespace Contentstack.Core.Models
         {
             try
             {
-                var result = await ExecuteRequest($"{BaseUrlPath}/ancestors");
+                var result = await TaxonomyRequestHelper.ExecuteRequest(_stack, $"{BaseUrlPath}/ancestors", UrlQueries);
                 var jObject = JObject.Parse(result);
-                var token = jObject.SelectToken("$.ancestors");
+                var token = jObject.SelectToken("$.terms");
                 if (token != null)
                     return token.ToObject<T>(_stack.Serializer);
                 return jObject.ToObject<T>(_stack.Serializer);
@@ -185,7 +217,7 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = Taxonomy.GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,
@@ -209,9 +241,9 @@ namespace Contentstack.Core.Models
         {
             try
             {
-                var result = await ExecuteRequest($"{BaseUrlPath}/descendants");
+                var result = await TaxonomyRequestHelper.ExecuteRequest(_stack, $"{BaseUrlPath}/descendants", UrlQueries);
                 var jObject = JObject.Parse(result);
-                var token = jObject.SelectToken("$.descendants");
+                var token = jObject.SelectToken("$.terms");
                 if (token != null)
                     return token.ToObject<T>(_stack.Serializer);
                 return jObject.ToObject<T>(_stack.Serializer);
@@ -222,7 +254,7 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = Taxonomy.GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,
@@ -232,27 +264,5 @@ namespace Contentstack.Core.Models
             }
         }
 
-        private async Task<string> ExecuteRequest(string url, Dictionary<string, object> extraParams = null)
-        {
-            var headerAll = new Dictionary<string, object>();
-            foreach (var header in _stack._LocalHeaders)
-                headerAll[header.Key] = header.Value;
-
-            var mainJson = new Dictionary<string, object>();
-            if (_stack.Config?.Environment != null)
-                mainJson["environment"] = _stack.Config.Environment;
-
-            if (extraParams != null)
-                foreach (var kvp in extraParams)
-                    mainJson[kvp.Key] = kvp.Value;
-
-            var handler = new HttpRequestHandler(_stack);
-            return await handler.ProcessRequest(
-                url, headerAll, mainJson,
-                Branch: _stack.Config.Branch,
-                timeout: _stack.Config.Timeout,
-                proxy: _stack.Config.Proxy
-            );
-        }
     }
 }

--- a/Contentstack.Core/Models/TermQuery.cs
+++ b/Contentstack.Core/Models/TermQuery.cs
@@ -80,6 +80,87 @@ namespace Contentstack.Core.Models
         }
 
         /// <summary>
+        /// Limits the depth of the term hierarchy returned in the response.
+        /// <c>Depth(1)</c> returns only root-level terms; higher values include deeper levels.
+        /// </summary>
+        /// <param name="depth">The maximum number of hierarchy levels to include.</param>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().Depth(1).Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery Depth(int depth)
+        {
+            UrlQueries["depth"] = depth;
+            return this;
+        }
+
+        /// <summary>
+        /// Includes branch information in the response for each term.
+        /// </summary>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().IncludeBranch().Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery IncludeBranch()
+        {
+            UrlQueries["include_branch"] = "true";
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the number of terms to skip in the result set (pagination offset).
+        /// </summary>
+        /// <param name="skip">The number of terms to skip. Must be &gt;= 0.</param>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var page2 = await stack.Taxonomies("gadgets").Terms().Skip(10).Limit(10).Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery Skip(int skip)
+        {
+            UrlQueries["skip"] = skip;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of terms to return.
+        /// </summary>
+        /// <param name="limit">The maximum result count.</param>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var terms = await stack.Taxonomies("gadgets").Terms().Limit(5).Find&lt;MyTerm&gt;();
+        /// </code>
+        /// </example>
+        public TermQuery Limit(int limit)
+        {
+            UrlQueries["limit"] = limit;
+            return this;
+        }
+
+        /// <summary>
+        /// Includes the total count of matching terms in the response.
+        /// Access it via <see cref="ContentstackCollection{T}.Count"/> on the result.
+        /// </summary>
+        /// <returns>The current <see cref="TermQuery"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        ///     var result = await stack.Taxonomies("gadgets").Terms().IncludeCount().Find&lt;MyTerm&gt;();
+        ///     Console.WriteLine($"Total terms: {result.Count}");
+        /// </code>
+        /// </example>
+        public TermQuery IncludeCount()
+        {
+            UrlQueries["include_count"] = "true";
+            return this;
+        }
+
+        /// <summary>
         /// Executes the query and returns all matching published terms.
         /// Maps to GET /v3/taxonomies/{uid}/terms with any configured query parameters.
         /// </summary>
@@ -94,24 +175,7 @@ namespace Contentstack.Core.Models
         {
             try
             {
-                var headerAll = new Dictionary<string, object>();
-                foreach (var header in _stack._LocalHeaders)
-                    headerAll[header.Key] = header.Value;
-
-                var mainJson = new Dictionary<string, object>();
-                if (_stack.Config?.Environment != null)
-                    mainJson["environment"] = _stack.Config.Environment;
-
-                foreach (var kvp in UrlQueries)
-                    mainJson[kvp.Key] = kvp.Value;
-
-                var handler = new HttpRequestHandler(_stack);
-                var result = await handler.ProcessRequest(
-                    Url, headerAll, mainJson,
-                    Branch: _stack.Config.Branch,
-                    timeout: _stack.Config.Timeout,
-                    proxy: _stack.Config.Proxy
-                );
+                var result = await TaxonomyRequestHelper.ExecuteRequest(_stack, Url, UrlQueries);
 
                 var jObject = JObject.Parse(result);
                 var terms = jObject.SelectToken("$.terms")?.ToObject<IEnumerable<T>>(_stack.Serializer);
@@ -125,7 +189,7 @@ namespace Contentstack.Core.Models
             }
             catch (Exception ex)
             {
-                var contentstackError = Taxonomy.GetContentstackError(ex);
+                var contentstackError = TaxonomyRequestHelper.GetContentstackError(ex);
                 throw new TaxonomyException(contentstackError.Message, ex)
                 {
                     ErrorCode = contentstackError.ErrorCode,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.29.0</Version>
+    <Version>2.30.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
feat: Taxonomy list-all endpoint + Term/TermQuery hierarchy support
## Summary
- Adds `Taxonomies().Find<T>()` for the previously-missing `GET /taxonomies` (list all published taxonomies) endpoint, bringing this branch to parity with the Taxonomy Publishing feature set added elsewhere
- Adds `Depth`/`IncludeBranch` modifiers to `Term` and `TermQuery`, and `Skip`/`Limit`/`IncludeCount` pagination to `TermQuery`.
- Consolidates the request-building, header-merging, and error-parsing logic that was duplicated across `Taxonomy.Fetch<T>()`, `Term`'s methods, and `TermQuery.Find<T>()` into a single `Internals/TaxonomyRequestHelper`. This also fixes a bug where `GetHeader`'s local-header merge existed but was never actually called from any live request path.
- Fixes a real deserialization bug in `Term.Locales<T>()`/`Ancestors<T>()`/`Descendants<T>()`: they were reading the JSON envelope under `$.locales`/`$.ancestors`/`$.descendants`, but the live CDA actually wraps all three under `$.terms`. Confirmed directly against the API - this silently returned the wrong (whole-envelope) object for loosely-typed callers and threw for strictly-typed ones (e.g. `JArray`).

## Test plan
- [x] `Contentstack.Core.Unit.Tests` (`TaxonomyUnitTests`): 73/73 passing - covers every new modifier (chaining, param-set) via reflection into `UrlQueries`, plus the moved `GetHeader`/`GetContentstackError` tests now targeting `TaxonomyRequestHelper` directly, plus the renamed `Taxonomy_Find_*` tests.
- [x] `Contentstack.Core.Tests` (`TaxonomyLocalisationTest`, live integration against the real test stack): 17/17 passing, including new tests for `Depth`/`IncludeBranch` on ancestor/descendant traversal (verified against a real `accessories` → `cases`/`chargers` term hierarchy) and the renamed `Find<T>()` list-all-taxonomies endpoint.
- [x] `Contentstack.Core.Tests` (`TaxonomySupportTest`, entry-filter regression check): 28/28 passing, but see the callout above - this does not prove the entry-filter feature is unaffected, only that its own assertions don't catch the change.
- [x] Manually diffed live CDA responses via `curl` for every envelope key (`$.taxonomy`, `$.taxonomies`, `$.term`, `$.terms`) to confirm correctness beyond what the existing loosely-typed tests would catch, and directly compared `GET /taxonomies/entries` vs `GET /taxonomies` responses to confirm the behavior-change callout above with real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)